### PR TITLE
Adapted docs to new naming and tokens

### DIFF
--- a/learn/token.md
+++ b/learn/token.md
@@ -1,17 +1,33 @@
 ---
-title: Glimmer Token
-description: Like all smart contract platforms, the Moonbeam Network will require a utility token to function, which is called Glimmer (GLMR).
+title: Tokens
+description: Like all smart contract platforms, the Moonbeam Network will require a utility token to function, which is called Glimmer (GLMR) for Polkadot, and River (RIVER) for Kusama.
 ---
 
-#Glimmer Token (GLMR)
-As a decentralized smart contract platform, Moonbeam requires a utility token to function.  In Moonbeam, this token will be called Glimmer as in, “that smart contract call will cost 3 Glimmer.”  The token symbol will be GLMR.
+# Introduction
 
-This token is central to the design of Moonbeam and cannot be removed without sacrificing essential functionality.  Some of the uses of the GLMR token on Moonbeam include:
+As a decentralized smart contract platform, Moonbeam requires a utility token to function.  
 
-* Supporting the gas metering of smart contract execution.
-* Incentivizing collators and powering the mechanics around the creation of a decentralized node infrastructure on which the platform can run.
-* Facilitating the on-chain governance mechanism including proposing referenda, electing council members, voting, etc.
-* Paying for transaction fees on the network.
+This token is central to the design of Moonbeam and cannot be removed without sacrificing essential functionality. Some of the uses of the token on Moonbeam include:
 
-!!! note
-    The issuance model, genesis allocation, incentives, fees, and token economics surrounding the GLMR token are still under development.  There will be further updates to this page once those details are finalized.
+ - Supporting the gas metering of smart contract execution
+ - Incentivizing collators and powering the mechanics around the creation of a decentralized node infrastructure on which the platform can run
+ - Facilitating the on-chain governance mechanism, including proposing referenda, electing council members, voting, etc
+ - Paying for transaction fees on the network
+
+## Glimmer Token
+
+In the Moonbeam deployment on Polkadot MainNet, this token will be called Glimmer, as in, “that smart contract call will cost 3 Glimmer.”  The token symbol will be GLMR.
+
+You can find more information in regards to Glimmer [in this link](https://moonbeam.network/networks/moonbeam/glimmer-token/).
+
+## River Token
+
+In the Moonbeam deployment on Kusama (called Moonriver), this token will be called River, as in, “that smart contract call will cost 3 River.”  The token symbol will be RIVER.
+
+You can find more information in regards to River [in this link](https://moonbeam.network/networks/moonriver/river-token/).
+
+## DEV Token
+
+In our Moonbeam TestNet (called Moonbase Alpha), the token is called DEV. This token can be acquired freely as its only purpose is to drive development and testing on Moonbase Alpha.
+
+You can get access to DEV tokens from our [faucet](https://docs.moonbeam.network/getting-started/testnet/faucet/).

--- a/networks/overview.md
+++ b/networks/overview.md
@@ -3,21 +3,37 @@ title: Overview
 description: An overview of the networks planned for Moonbeam, an Ethereum-compatible smart contract parachain on Polkadot.
 ---
 
-#Networks  
+# Networks
+
 We plan to create multiple long-lived, Moonbeam-based networks. Significantly, Moonbeam will be deployed to Kusama in addition to Polkadot.
 
-Our approach will be first to deploy a PureStake hosted parachain TestNet, followed by a parachain deployed to the Rococo TestNet, then Moonbeam to Kusama, and finally to the Polkadot Network. Deploying in this way allows us to de-risk software upgrades to Moonbeam on the Polkadot MainNet while still maintaining a reasonable update velocity. We will add details on how to access different Moonbeam-based networks as the networks become available.
+Our roadmap in regards to deployments as a parachain is the following:
 
-##Moonbeam TestNet - Moonbase Alpha
-This Alpha TestNet, named Moonbase Alpha, is a network that is hosted by PureStake. It features a parachain-relay chain scheme with one collator and three validators. The goal is to allow developers to test the Ethereum compatibility features of Moonbeam without needing to run their own nodes or network, and in a shared environment that is parachain. [Learn more about Moonbase Alpha](/networks/testnet/).
+ - Moonbase Alpha: PureStake hosted parachain TestNet (_September 2020_) 
+ - Moonrock: deployment on the Rococo TestNet (_tbd_)
+ - Moonriver: deployment on Kusama (_end of Q1 2021_)
+ - Moonbeam: deployment on Polkadot (_end of Q2 2021_)
+ 
+This strategy allows us to de-risk software upgrades to Moonbeam on the Polkadot MainNet while still maintaining a reasonable update velocity. We will add details on how to access different Moonbeam-based networks as the networks become available.
 
-For future releases, Moonbase Alpha may support third-party collators, so they can test their setups.
+## Moonbase Alpha
 
-##Moonbeam RococoNet  
-Moonbeam will be deployed as a parachain on the Rococo TestNet. This deployment will provide a place to test interoperability with other chains as they, and the corresponding features, become available in Rococo.
+This TestNet is a network that is hosted by PureStake. It features a parachain-relay chain scheme. The goal is to allow developers to test the Ethereum compatibility features of Moonbeam without needing to run their own nodes or network, and in a shared environment that is parachain.
 
-##Moonbeam KusamaNet  
-Moonbeam will launch as a parachain on the Kusama network, in advance of deploying to the Polkadot MainNet ([more details here](https://www.purestake.com/news/moonbeam-on-kusama/)). This requires parachain functionality to be live on Kusama. We plan to exercise parachain-related functionality such as IPO, XCMP, and SPREE on our KusamaNet as those features become available.
+[Learn more about Moonbase Alpha](/networks/testnet/).
 
-##Moonbeam Polkadot MainNet  
+## Moonrock  
+
+We have decided not to take place in the first parachains deployments to Rococo, since we've been running a parachain relay-chain setup since we launched our TestNet in September 2020.
+
+However, we expect to deploy Moonbeam as a parachain on the Rococo TestNet once interoperability features become available. This will provide a place to test these features with other chains.
+
+## Moonriver
+
+Moonbeam will launch as a parachain on the Kusama network, in advance of deploying to the Polkadot MainNet ([more details here](https://www.purestake.com/news/moonbeam-on-kusama/)). This requires parachain functionality to be live on Kusama. 
+
+We plan to exercise parachain-related functionality such as [Crowdloan](https://wiki.polkadot.network/docs/en/learn-crowdloans), [XCMP](https://wiki.polkadot.network/docs/en/learn-crossch), and [SPREE](https://wiki.polkadot.network/docs/en/learn-spree) on Moonriver as those features become available.
+
+## Moonbeam Polkadot MainNet
+
 The Moonbeam production MainNet will be deployed as a parachain on Polkadot. This Moonbeam network will feature the highest levels of security and availability. Code running on the MainNet will generally have been vetted through one or more of the other networks listed above.

--- a/resources/roadmap.md
+++ b/resources/roadmap.md
@@ -3,9 +3,13 @@ title: Roadmap
 description: Moonbeam launched its first TestNet in September 2020, with a BetaNet on Kusama and MainNet on Polkadot to follow in early 2021.
 ---
 
-#Roadmap
-Moonbeam is currently pre-alpha software. We are working on the implementation of the minimum feature set, which will be needed to launch a [TestNet](/resources/networks/) in Q3 2020. The rough roadmap beyond that is to launch on Kusama in Q1 2021 and on the Polkadot MainNet in Q2 2021.
+# Roadmap
 
-Our current focus is on making sure the Moonbeam EVM and Web3 compatibility features are feature-complete. A big part of this effort is the completion of the Web3 grant we received to implement a Web3-compatible RPC API.  Details of the grant can be found [here](https://github.com/w3f/Open-Grants-Program/blob/master/applications/web3-compatible-api.md).  The work we did for this grant was completed and [approved in August 2020](https://www.purestake.com/news/purestake-awarded-web3-foundation-grant-moonbeam/).
+Moonbeam is still being actively developed. 
 
-We have several critical components in our backlog that plan to work on next, including the implementation of an Ethereum-compatible account system in Moonbeam and functionality to power collator mechanics and incentives in Moonbeam.
+On September 2020, launched our [TestNet](/resources/networks/). Since then we have performed significants upgrades to it on almost a monthly basis. You can check the milestones achieved by each update in their corresponding [release notes](/networks/testnet/#release-notes).
+
+
+The rough roadmap beyond that is to launch Moonriver, our Kusama deployment, by the end of Q1 2021, and Moonbeam on the Polkadot MainNet in Q2 2021.
+
+Our current focus is on making sure the Moonbeam EVM and Web3 compatibility features are feature-complete. A big part of this effort was completing the Web3 grant we received to implement a Web3-compatible RPC API. Details of the grant can be found [here](https://github.com/w3f/Open-Grants-Program/blob/master/applications/web3-compatible-api.md).  The work we did for this grant was completed and [approved in August 2020](https://www.purestake.com/news/purestake-awarded-web3-foundation-grant-moonbeam/).


### PR DESCRIPTION
In this PR I've modified token page, network overview page and roadmap.

The idea is to adapt the page to the new network naming convention:
Moonbase Alpha: TestNet
Moonrock: deployment on Rococo
Moonriver: deployment on Kusama
Moonbeam: deployment on Polkadot

I've also modified the Token page to include the links of the River and Glimmer token site on moonbeam.network

The roadmap was slightly updated as we've achieved some of the milestones already.