### PR TITLE
Client upgrade docs

### DIFF
--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -334,11 +334,15 @@ sudo docker stop `CONTAINER_ID`
 sudo systemctl stop moonbeam
 ```
 
-Next, remove the `db` folder, where the parachain information is stored:
+!!! Purging the Chain
 
-```
-sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
-```
+    Occasionally Moonbase Alpha might be purged and reset around major upgrades.
+    If this upgrade is accompanied by a purge, you will need a fresh new data directory.
+    Remove the `db` folder, where the parachain information is stored:
+
+    ```
+    sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
+    ```
 
 Lastly, install the new version and/or start the service again.  
 

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -324,7 +324,7 @@ journalctl -f -u moonbeam.service
 
 ## Updating the Client
 
-As Moonbeam development continues, it will sometimes be necessary to upgrade your node software. Node operators will be notified on our [Discord channel](https://discord.gg/PfpUATX) when upgrades are available, and whether they are necessary (some client upgrades are optional). The upgrade process is straightforward, and is the same for a full node or collator.  
+As Moonbeam development continues, it will sometimes be necessary to upgrade your node software. Node operators will be notified on our [Discord channel](https://discord.gg/PfpUATX) when upgrades are available and whether they are necessary (some client upgrades are optional). The upgrade process is straightforward and is the same for a full node or collator.  
 
 First, stop the docker container or systemd service:
 
@@ -333,7 +333,7 @@ sudo docker stop `CONTAINER_ID`
 # or
 sudo systemctl stop moonbeam
 ```
-Then, just install the new version, after which, you can start the service again.
+Then, install the new version by repeating the steps described before, making sure that you are using the latest tag available. After updating, you can start the service again.
 
 ### Purging the Chain
 
@@ -352,7 +352,7 @@ Next, remove the `db` folder, where the parachain information is stored:
 sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
 ```
 
-Lastly, make sure that you are running the latest version. If so, you can start a new node with a fresh data directory.
+Lastly, install the newest version by repeating the steps described before, making sure you are using the latest tag available. If so, you can start a new node with a fresh data directory.
 
 ## Telemetry
 

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -322,9 +322,9 @@ journalctl -f -u moonbeam.service
 
 ![Service Logs](/images/fullnode/fullnode-binary3.png)
 
-## Purging the Chain
+## Updating the Client
 
-Occasionally Moonbase Alpha might be purged for upgrades.  Node operators will be notified on our Discord channel when this is necessary. In this section, the steps to purge the parachain are outlined, it's the same for a full node or collator.  
+As Moonbeam development continues, it will sometimes be necessary to upgrade your node software. Node operators will be notified on our Discord channel upgrades are available, and whether they are necessary (some client upgrades are optional). The upgrade process is straightforward, and the same for a full node or collator.  
 
 First, stop the docker container or systemd service:
 
@@ -337,14 +337,31 @@ sudo systemctl stop moonbeam
 !!! Purging the Chain
 
     Occasionally Moonbase Alpha might be purged and reset around major upgrades.
-    If this upgrade is accompanied by a purge, you will need a fresh new data directory.
-    Remove the `db` folder, where the parachain information is stored:
+    If this upgrade is accompanied by a purge, you will need a fresh data directory.
+    See [Purging the Chain] below for instructions.
+    TODO ^^ @alberto, How do I link to another section in this document?
 
-    ```
-    sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
-    ```
 
-Lastly, install the new version and/or start the service again.  
+Lastly, install the new version and/or start the service again.
+
+## Purging the Chain
+
+You may periodically need to purge your chain data. This can happen when the entire network agrees to purge and relaunch a new chain. Or when your individual data directory becomes corrupted.
+
+First, stop the docker container or systemd service:
+```
+sudo docker stop `CONTAINER_ID`
+# or
+sudo systemctl stop moonbeam
+```
+
+Remove the `db` folder, where the parachain information is stored:
+
+```
+sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
+```
+
+You're now ready to start a new service with a fresh data directory.
 
 ## Telemetry
 

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -324,7 +324,7 @@ journalctl -f -u moonbeam.service
 
 ## Updating the Client
 
-As Moonbeam development continues, it will sometimes be necessary to upgrade your node software. Node operators will be notified on our Discord channel upgrades are available, and whether they are necessary (some client upgrades are optional). The upgrade process is straightforward, and the same for a full node or collator.  
+As Moonbeam development continues, it will sometimes be necessary to upgrade your node software. Node operators will be notified on our [Discord channel](https://discord.gg/PfpUATX) when upgrades are available, and whether they are necessary (some client upgrades are optional). The upgrade process is straightforward, and is the same for a full node or collator.  
 
 First, stop the docker container or systemd service:
 
@@ -333,35 +333,26 @@ sudo docker stop `CONTAINER_ID`
 # or
 sudo systemctl stop moonbeam
 ```
+Then, just install the new version, after which, you can start the service again.
 
-!!! Purging the Chain
+### Purging the Chain
 
-    Occasionally Moonbase Alpha might be purged and reset around major upgrades.
-    If this upgrade is accompanied by a purge, you will need a fresh data directory.
-    See [Purging the Chain] below for instructions.
-    TODO ^^ @alberto, How do I link to another section in this document?
+Occasionally Moonbase Alpha might be purged and reset around major upgrades. As always, node operators will be notified in advance (via our [Discord channel](https://discord.gg/PfpUATX)) if this upgrade is accompanied by a purge. You can also purge your node if your individual data directory becomes corrupted.
 
-
-Lastly, install the new version and/or start the service again.
-
-## Purging the Chain
-
-You may periodically need to purge your chain data. This can happen when the entire network agrees to purge and relaunch a new chain. Or when your individual data directory becomes corrupted.
-
-First, stop the docker container or systemd service:
+To do so, first stop the docker container or systemd service:
 ```
 sudo docker stop `CONTAINER_ID`
 # or
 sudo systemctl stop moonbeam
 ```
 
-Remove the `db` folder, where the parachain information is stored:
+Next, remove the `db` folder, where the parachain information is stored:
 
 ```
 sudo rm -rf {{ networks.moonbase.node_directory }}{{ networks.moonbase.node_db_loc }}
 ```
 
-You're now ready to start a new service with a fresh data directory.
+Lastly, make sure that you are running the latest version. If so, you can start a new node with a fresh data directory.
 
 ## Telemetry
 

--- a/variables.yml
+++ b/variables.yml
@@ -8,7 +8,7 @@ networks:
       rpc_url: https://rpc.testnet.moonbeam.network
       chain_id: 1287
       parachain_docker_sha: sha-02fbb7e2
-      parachain_docker_tag: v0.6.0
+      parachain_docker_tag: v0.6.1
       node_directory: /var/lib/alphanet-data
       node_db_loc: /chains/moonbase_alpha/db
       binary_name: moonbeam


### PR DESCRIPTION
This PR adds docs explaining how to upgrade ones client, and distinguished regular upgrades from upgrades that are accompanied by a network-wide purge.

This documentation is generally useful, and is also timely as we are planning a client upgrade for Alphanet associated with the https://github.com/PureStake/moonbeam/releases/tag/v0.6.1 release.