### PR TITLE
Added peers and pruning, minor mod

### DIFF
--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -97,6 +97,7 @@ Now we can execute the docker run command. Note that you have to:
     --out-peers 200 \
     --pruning archive \
     -- \
+    --pruning archive \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -116,6 +117,7 @@ Now we can execute the docker run command. Note that you have to:
     --out-peers 200 \
     --pruning archive \
     -- \
+    --pruning archive \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -256,7 +258,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --name "YOUR-NODE-NAME" \
         --in-peers 200 \
         --out-peers 200 \
-        --pruning archive \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
@@ -302,7 +303,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --name "YOUR-NODE-NAME" \
          --in-peers 200 \
          --out-peers 200 \
-         --pruning archive \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -11,7 +11,7 @@ description: How to run a full Parachain node for the Moonbeam Network to have y
 
 With the release of Moonbase Alpha v6, you can spin up a node that connects to the Moonbase Alpha TestNet, syncs with a bootnode, provides local access your RPC endpoints, and even authors blocks on the parachain. 
 
-In our TestNet, the relay chain is hosted and run by PureStake. But as development progresses, there will also be deployments in Kusama and then Polkadot.  Here's how we will name these upcoming environments and their corresponding [chain specification files](https://substrate.dev/docs/en/knowledgebase/integrate/chain-spec) name: 
+In our TestNet, the relay chain is hosted and run by PureStake. But as development progresses, there will also be deployments in Kusama and then Polkadot.  Here's how these upcoming environments will be named and their corresponding [chain specification files](https://substrate.dev/docs/en/knowledgebase/integrate/chain-spec) name: 
 
 |      Network      |   |     Hosted By    |   |   Chain Name  |
 |:-----------------:|:-:|:----------------:|:-:|:-------------:|
@@ -22,7 +22,7 @@ In our TestNet, the relay chain is hosted and run by PureStake. But as developme
 This guide is meant for people with experience running [Substrate](https://substrate.dev/) based chains.  Running a parachain is similar to running a Substrate node with a few differences. A Substrate parachain node will run two processes: one to sync the relay chain and one to sync the parachain.  As such, many things are doubled, for example, the database directory, the ports used, the log lines, and more.
 
 !!! note 
-    Moonbase Alpha is still considered an Alphanet, and as such *will not* have 100% uptime.  We *will* be purging the parachain from time to time. During the development of your application, make sure you implement a method to redeploy your contracts and accounts to a fresh parachain quickly. We will announce when a chain purge will take place via our [Discord channel](https://discord.gg/PfpUATX) at least 24 hours in advance.
+    Moonbase Alpha is still considered an Alphanet, and as such *will not* have 100% uptime. The parachain *will* be purged from time to time. During the development of your application, make sure you implement a method to redeploy your contracts and accounts to a fresh parachain quickly. Chain purges will be announced via our [Discord channel](https://discord.gg/PfpUATX) at least 24 hours in advance.
 
 ## Requirements
 
@@ -66,17 +66,26 @@ The only ports that need to be open for incoming traffic are those designated fo
 
 A Moonbase Alpha node can be spun up quickly using Docker. For more information on installing Docker, please visit [this page](https://docs.docker.com/get-docker/). At the time of writing, the Docker version used was 19.03.6.
 
-First, we need to create a local directory to store the chain data and set the necessary permissions (replace `DOCKER_USER` for the actual user that will run the `docker` command):
+First, create a local directory to store the chain data:
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
+```
+
+Next, set the necessary permissions either for a specific or current user (replace `DOCKER_USER` for the actual user that will run the `docker` command):
+
+```
+# chown to a specific user
 chown DOCKER_USER {{ networks.moonbase.node_directory }}
+
+# chown to current user
+sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
 ```
 
 !!! note
     Make sure you set the ownership and permissions accordingly for the local directory that stores the chain data. 
 
-Now we can execute the docker run command. Note that you have to:
+Now, execute the docker run command. Note that you have to:
  - Replace `YOUR-NODE-NAME` in two different places.
  - For collators, replace `PUBLIC_KEY` with the public address that will be associated with collation activities.
 
@@ -145,7 +154,7 @@ Once synced, you have a node of the Moonbase Alpha TestNet running locally!
 
 ## Installation Instructions - Binary
 
-In this section, we'll go through the process of compiling the binary and running a Moonbeam full node as a systemd service. The following steps were tested on an Ubuntu 18.04 installation. Moonbase Alpha may work with other Linux flavors, but Ubuntu is currently the only tested version.  
+This section goes through the process of compiling the binary and running a Moonbeam full node as a systemd service. The following steps were tested on an Ubuntu 18.04 installation. Moonbase Alpha may work with other Linux flavors, but Ubuntu is currently the only tested version.  
 
 ### Compiling the Binary 
 
@@ -169,13 +178,13 @@ Next, install Substrate and all its prerequisites, including Rust, by executing:
 --8<-- 'setting-up-local/substrate.md'
 ```
 
-Now, we need to make some checks (correct version of Rust nightly) with the initialization script:
+Now, make some checks (correct version of Rust nightly) with the initialization script:
 
 ```
 --8<-- 'setting-up-local/initscript.md'
 ```
 
-Lastly, let's build parachain binary:
+Lastly, build parachain binary:
 
 ```
 cargo build --release
@@ -198,7 +207,7 @@ First, let's create a service account to run the service:
 adduser moonbase_service --system --no-create-home
 ```
 
-Next, we need to create a directory to store the binary and data. We'll also set the necessary permissions:
+Next, create a directory to store the binary and data and set the necessary permissions:
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
@@ -208,7 +217,7 @@ chown moonbase_service {{ networks.moonbase.node_directory }}
 !!! note
     Make sure you set the ownership and permissions accordingly for the local directory that stores the chain data.
 
-Now, we need to copy the binary we built in the last section to the created folder:
+Now, copy the binary built in the last section to the created folder:
 
 ```
 cp ./target/release/{{ networks.moonbase.binary_name }} {{ networks.moonbase.node_directory }}
@@ -319,7 +328,7 @@ The next step is to create the systemd configuration file. Note that you have to
 !!! note
     You can specify a custom Prometheus port with the `--promethues-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
 
-We are almost there! We need to register and start the service by running:
+Almost there! Register and start the service by running:
 
 ```
 systemctl enable moonbeam.service
@@ -334,7 +343,7 @@ systemctl status moonbeam.service
 
 ![Service Status](/images/fullnode/fullnode-binary2.png)
 
-We can also check the logs by executing:
+You can also check the logs by executing:
 
 ```
 journalctl -f -u moonbeam.service

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -70,11 +70,11 @@ First, we need to create a local directory to store the chain data and set the n
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
+sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
 ```
 
 !!! note
-    Make sure you set the ownership and permissions accordingly for the local directory that stores the chain data using the `chown` and `chmod` commands. 
-
+    Make sure you set the ownership and permissions accordingly for the local directory that stores the chain data. 
 
 Now we can execute the docker run command. Note that you have to:
  - Replace `YOUR-NODE-NAME` in two different places.
@@ -93,6 +93,9 @@ Now we can execute the docker run command. Note that you have to:
     --name="YOUR-NODE-NAME" \
     --execution wasm \
     --wasm-execution compiled \
+    --in-peers 200 \
+    --out-peers 200 \
+    --pruning archive \
     -- \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
@@ -109,6 +112,9 @@ Now we can execute the docker run command. Note that you have to:
     --author-id PUBLIC_KEY \
     --execution wasm \
     --wasm-execution compiled \
+    --in-peers 200 \
+    --out-peers 200 \
+    --pruning archive \
     -- \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
@@ -118,7 +124,10 @@ Once Docker pulls the necessary images, your Moonbase Alpha full node will start
 ![Full Node Starting](/images/fullnode/fullnode-docker1.png)
 
 !!! note
-    Running telemetry is not mandatory for full nodes, only collators. You can add the flag `--no-telemetry` to run the full node without telemetry activated.
+    If you are having issues with the default telemetry, you can add the flag `--no-telemetry` to run the full node without telemetry activated.
+
+!!! note
+    You can specify a custom Prometheus port with the `--promethues-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
 
 The command above will enable all exposed ports, including the P2P, RPC, and Prometheus (telemetry) ports.  This command is compatible to use with the Gantree Node Watchdog telemetry.  If you want to expose specific ports, enable those on the Docker run command line as shown below. However, doing so will block the Gantree Node Watchdog (telemetry) container from accessing the moonbeam container, so don't do this when running a collator unless you understand [docker networking](https://docs.docker.com/network/).
 
@@ -191,9 +200,12 @@ Next, we need to create a directory to store the binary and data. We'll also set
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
-chmod 0755 {{ networks.moonbase.node_directory }}
+sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
 chown moonbase_service {{ networks.moonbase.node_directory }}
 ```
+
+!!! note
+    Make sure you set the ownership and permissions accordingly for the local directory that stores the chain data.
 
 Now, we need to copy the binary we built in the last section to the created folder:
 
@@ -242,6 +254,9 @@ The next step is to create the systemd configuration file. Note that you have to
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \
          --name "YOUR-NODE-NAME" \
+        --in-peers 200 \
+        --out-peers 200 \
+        --pruning archive \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
@@ -285,6 +300,9 @@ The next step is to create the systemd configuration file. Note that you have to
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \
          --name "YOUR-NODE-NAME" \
+         --in-peers 200 \
+         --out-peers 200 \
+         --pruning archive \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
@@ -297,7 +315,10 @@ The next step is to create the systemd configuration file. Note that you have to
     ``` 
 
 !!! note
-    Running telemetry is not mandatory for full nodes. You can add the flag `--no-telemetry` to run the full node without telemetry activated.
+    If you are having issues with the default telemetry, you can add the flag `--no-telemetry` to run the full node without telemetry activated.
+
+!!! note
+    You can specify a custom Prometheus port with the `--promethues-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
 
 We are almost there! We need to register and start the service by running:
 

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -66,11 +66,11 @@ The only ports that need to be open for incoming traffic are those designated fo
 
 A Moonbase Alpha node can be spun up quickly using Docker. For more information on installing Docker, please visit [this page](https://docs.docker.com/get-docker/). At the time of writing, the Docker version used was 19.03.6.
 
-First, we need to create a local directory to store the chain data and set the necessary permissions:
+First, we need to create a local directory to store the chain data and set the necessary permissions (replace `DOCKER_USER` for the actual user that will run the `docker` command):
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
-sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
+chown DOCKER_USER {{ networks.moonbase.node_directory }}
 ```
 
 !!! note
@@ -202,7 +202,6 @@ Next, we need to create a directory to store the binary and data. We'll also set
 
 ```
 mkdir {{ networks.moonbase.node_directory }}
-sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
 chown moonbase_service {{ networks.moonbase.node_directory }}
 ```
 


### PR DESCRIPTION
Added the `--in-peers` and `--out-peers` flag to both docker and running as a service tutorial (only parachain, set to 200). Also added the `--pruning=archive` flag docker command.

Have not tested the steps to see if they work.

Also modified the permissions settings so that users only need to run
`sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}`