### PR TITLE
Add connect metamask buttons

### DIFF
--- a/getting-started/local-node/using-metamask.md
+++ b/getting-started/local-node/using-metamask.md
@@ -82,39 +82,5 @@ If you head back over to your terminal where you have your Moonbeam node running
 
 !!! note
     If you end up resetting your development node using the Substrate purge-chain command, you will need to reset your MetaMask genesis account using Settings -> Advanced -> Reset Account. This will clear the transaction history from your accounts and reset the nonce. Make sure you don’t erase anything that you want to keep!
-
-
-## One-click Connect to MetaMask
-
-<div>
-    <button class="connect">Connect MetaMask to Moonbase Alpha</button>
-    <script>
-        document.querySelector(".connect").onclick = () => setupMoonbaseAlpha();
-        const setupMoonbaseAlpha = () => {
-            const provider = window.ethereum;
-            if (provider) {
-                provider.request({ method: "eth_requestAccounts"})
-                provider.request({
-                    method: "wallet_addEthereumChain",
-                    params: [
-                        {
-                            chainId: `0x507`,
-                            chainName: "Moonbase Alpha",
-                            nativeCurrency: {
-                                name: 'DEV',
-                                symbol: 'DEV',
-                                decimals: 18
-                            },
-                            rpcUrls: ["https://rpc.testnet.moonbeam.network"],
-                            blockExplorerUrls: ["https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.testnet.moonbeam.network#/explorer"],
-                        },
-                    ]
-                })
-            } else {
-                console.log("Uh oh! Looks like you need to install MetaMask")
-            }
-        }
-    </script>
-</div>
  
 --8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/local-node/using-metamask.md
+++ b/getting-started/local-node/using-metamask.md
@@ -83,5 +83,38 @@ If you head back over to your terminal where you have your Moonbeam node running
 !!! note
     If you end up resetting your development node using the Substrate purge-chain command, you will need to reset your MetaMask genesis account using Settings -> Advanced -> Reset Account. This will clear the transaction history from your accounts and reset the nonce. Make sure you don’t erase anything that you want to keep!
 
+
+## One-click Connect to MetaMask
+
+<div>
+    <button class="connect">Connect MetaMask to Moonbase Alpha</button>
+    <script>
+        document.querySelector(".connect").onclick = () => setupMoonbaseAlpha();
+        const setupMoonbaseAlpha = () => {
+            const provider = window.ethereum;
+            if (provider) {
+                provider.request({ method: "eth_requestAccounts"})
+                provider.request({
+                    method: "wallet_addEthereumChain",
+                    params: [
+                        {
+                            chainId: `0x507`,
+                            chainName: "Moonbase Alpha",
+                            nativeCurrency: {
+                                name: 'DEV',
+                                symbol: 'DEV',
+                                decimals: 18
+                            },
+                            rpcUrls: ["https://rpc.testnet.moonbeam.network"],
+                            blockExplorerUrls: ["https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.testnet.moonbeam.network#/explorer"],
+                        },
+                    ]
+                })
+            } else {
+                console.log("Uh oh! Looks like you need to install MetaMask")
+            }
+        }
+    </script>
+</div>
  
 --8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/testnet/metamask.md
+++ b/getting-started/testnet/metamask.md
@@ -9,6 +9,12 @@ description: Learn how to use MetaMask with the Moonbeam TestNet. This tutorial 
 
 This guide outlines the steps needed to connect MetaMask to Moonbase Alpha. In contrast to our previous MetaMask guide, this is much simpler because you don't need to connect to a local running Moonbeam node. Let's jump right into it.
 
+If you already have MetaMask installed, you can easily connect MetaMask to the Moonbase Alpha test network:
+
+[Connect MetaMask](#){ .md-button .connectMetaMask }
+
+!!! note
+    MetaMask will popup asking for permission to add Moonbase Alpha as a custom network. Once you approve permissions, MetaMask will switch your current network to Moonbase Alpha.
 ## Creating a Wallet
 
 After installing [MetaMask](https://metamask.io), the setup will automatically open a new task with a welcome screen. Click "Get Started" to begin the setup process.

--- a/getting-started/testnet/metamask.md
+++ b/getting-started/testnet/metamask.md
@@ -11,7 +11,9 @@ This guide outlines the steps needed to connect MetaMask to Moonbase Alpha. In c
 
 If you already have MetaMask installed, you can easily connect MetaMask to the Moonbase Alpha test network:
 
-[Connect MetaMask](#){ .md-button .connectMetaMask }
+<div class="button-wrapper">
+    <a href="#" class="md-button connectMetaMask">Connect MetaMask</a>
+</div>
 
 !!! note
     MetaMask will popup asking for permission to add Moonbase Alpha as a custom network. Once you approve permissions, MetaMask will switch your current network to Moonbase Alpha.

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -25,7 +25,6 @@ const setupMoonbaseAlpha = async () => {
                 ]
             })
         } catch(e) {
-            console.error(e);
             /** Code 4001 is user rejected, we don't need to notify the user if they rejected the request */
             if (e.code !== 4001) {
                 errorModalContainer.style.display = "block";
@@ -35,7 +34,6 @@ const setupMoonbaseAlpha = async () => {
     } else {
         errorModalContainer.style.display = "block";
         errorMessage.innerHTML = `It looks like MetaMask hasn't been installed. Please <a href="https://metamask.io/download.html" target="_blank" rel="noreferrer noopener">install MetaMask</a> and try again.`
-        console.log("error!");
     }
 }
 

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -1,4 +1,5 @@
 const provider = window.ethereum;
+const moonbaseAlphaChainId = "0x507";
 
 /** Connect to Moonbase Alpha */
 const setupMoonbaseAlpha = async () => {
@@ -13,7 +14,7 @@ const setupMoonbaseAlpha = async () => {
                 method: "wallet_addEthereumChain",
                 params: [
                     {
-                        chainId: "0x507",
+                        chainId: moonbaseAlphaChainId,
                         chainName: "Moonbase Alpha",
                         nativeCurrency: {
                             name: 'DEV',
@@ -53,15 +54,16 @@ connectMetaMaskNav.addEventListener("click", () => {
 })
 
 /** If we are already connected to Moonbase Alpha, show disbled button with 'Connected' text */
+const connectButtons = [connectMetaMask, connectMetaMaskNav];
 const isConnectedToMoonbaseAlpha = async () => {
     const chainId = await provider.request({
         method: 'eth_chainId'
     })
-    if (chainId === "0x507"){
-        connectMetaMask.innerHTML = "Connected";
-        connectMetaMask.className += " disabled-button";
-        connectMetaMaskNav.innerHTML = "Connected";
-        connectMetaMaskNav.className += " disabled-button";
+    if (chainId === moonbaseAlphaChainId){
+        connectButtons.forEach((button) => {
+            button.innerHTML = "Connected";
+            button.className += " disabled-button";
+        })
     }
 }
 

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -1,0 +1,70 @@
+const provider = window.ethereum;
+
+/** Connect to Moonbase Alpha */
+const setupMoonbaseAlpha = async () => {
+    if (provider) {
+        try {
+            await provider.request({ method: "eth_requestAccounts"});
+            await provider.request({
+                method: "wallet_addEthereumChain",
+                params: [
+                    {
+                        chainId: "0x507",
+                        chainName: "Moonbase Alpha",
+                        nativeCurrency: {
+                            name: 'DEV',
+                            symbol: 'DEV',
+                            decimals: 18
+                        },
+                       rpcUrls: ["https://rpc.testnet.moonbeam.network"],
+                    },
+                ]
+            })
+        } catch(e) {
+            console.error(e);
+        }
+    } else {
+        console.log("error!");
+    }
+}
+
+/**  Add event listener to the Connect MetaMask buttons */
+const connectMetaMask = document.querySelector(".connectMetaMask");
+const connectMetaMaskNav = document.querySelector(".connectMetaMask-nav");
+
+// If user is not on Integrate MetaMask page, connectMetaMask will not be available so
+// we need to check if it's there before adding the event listener to it
+if (connectMetaMask) {
+    connectMetaMask.addEventListener("click", () => {
+        setupMoonbaseAlpha();
+    })
+}
+connectMetaMaskNav.addEventListener("click", () => {
+    setupMoonbaseAlpha();
+})
+
+/** If we are already connected to Moonbase Alpha, show disbled button with 'Connected' text */
+const isConnectedToMoonbaseAlpha = async () => {
+    const chainId = await provider.request({
+        method: 'eth_chainId'
+    })
+    if (chainId === "0x507"){
+        connectMetaMask.innerHTML = "Connected";
+        connectMetaMask.className += " disabled-button";
+        connectMetaMaskNav.innerHTML = "Connected";
+        connectMetaMaskNav.className += " disabled-button";
+    }
+}
+
+if (provider) {
+    /** Check if user is connected to Moonbase Alpha and display correct button text */
+    isConnectedToMoonbaseAlpha();
+    
+    /** Reload the page if the chain changes */
+    provider.on("chainChanged", () => {
+        // MetaMask recommends reloading the page unless we have good reason not to
+        // Plus, everytime the window reloads, we call isConnectedToMoonbaseAlpha again
+        // and can show the correct 'Connected' or 'Connect MetaMask' button text
+        window.location.reload();
+    })
+}

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -22,6 +22,7 @@ const setupMoonbaseAlpha = async () => {
                             decimals: 18
                         },
                        rpcUrls: ["https://rpc.testnet.moonbeam.network"],
+                       blockExplorerUrls: ["https://moonbase-blockscout.testnet.moonbeam.network/"]
                     },
                 ]
             })

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -2,6 +2,10 @@ const provider = window.ethereum;
 
 /** Connect to Moonbase Alpha */
 const setupMoonbaseAlpha = async () => {
+    /** In case we need to throw an error, let's grab the error modal & error message */
+    const errorModalContainer = document.querySelector(".error-modal-container");
+    const errorMessage = document.querySelector(".error-message");
+
     if (provider) {
         try {
             await provider.request({ method: "eth_requestAccounts"});
@@ -22,8 +26,15 @@ const setupMoonbaseAlpha = async () => {
             })
         } catch(e) {
             console.error(e);
+            /** Code 4001 is user rejected, we don't need to notify the user if they rejected the request */
+            if (e.code !== 4001) {
+                errorModalContainer.style.display = "block";
+                errorMessage.innerHTML = e.message;
+            }
         }
     } else {
+        errorModalContainer.style.display = "block";
+        errorMessage.innerHTML = `It looks like MetaMask hasn't been installed. Please <a href="https://metamask.io/download.html" target="_blank" rel="noreferrer noopener">install MetaMask</a> and try again.`
         console.log("error!");
     }
 }

--- a/js/errorModal.js
+++ b/js/errorModal.js
@@ -1,0 +1,35 @@
+/** Grab the body so we can append the modal to it */
+const main = document.querySelector("main");
+
+/** Create the modal */
+const modalContainer = document.createElement("div");
+const modal = document.createElement("div");
+const modalHeader = document.createElement("h3");
+const modalMessage = document.createElement("p");
+const closeModal = document.createElement("span"); // maybe needs to be a div
+
+/** Add classes to modal elements so we can find and update as needed */
+modalContainer.className = "error-modal-container";
+modalHeader.className = "error-modal-header";
+modal.className = "error-modal";
+modalMessage.className = "error-message";
+closeModal.className = "close-modal";
+
+/** Set the display to none to hide the modal until it is needed */
+modalContainer.style.display = "none";
+
+/** Set generic header for the error modal */
+modalHeader.textContent = "There was a problem connecting MetaMask to Moonbase Alpha";
+
+/** Set up close button */
+closeModal.innerHTML = "&times;"
+closeModal.onclick = () => {
+    modalContainer.style.display = "none";
+}
+
+/** Put the modal together and append it to the main area on the page */
+modal.appendChild(closeModal);
+modal.appendChild(modalHeader);
+modal.appendChild(modalMessage);
+modalContainer.appendChild(modal);
+main.prepend(modalContainer);


### PR DESCRIPTION
This PR handles the logic for adding two "Connect MetaMask" buttons. One on the Getting Started > Testnet > Integrate MetaMask page of the documentation and the other on the nav bar.

In order to add the custom logic for connecting to MetaMask and handling errors, [it is recommended](https://squidfunk.github.io/mkdocs-material/customization/#additional-javascript) to use the `extra_javascript` configuration in the `mkdocs.yml`. So in that configuration, you'll find the entry point to `js/connectMetaMask.js` and `js/errorModal.js`.

There was not a semantically correct way for me to add the error modal directly to our `html` files in the `moonbeam-mkdocs` repo. As the only places it would have worked correctly would have been the header or footer and that's not really where it belongs. So I think appending the error modal dynamically was the best way to handle it. 

This PR goes hand-in-hand with [PR#2 on the `moonbeam-mkdocs` repo.](https://github.com/PureStake/moonbeam-mkdocs/pull/2)