### PR TITLE
Fix Connect MetaMask bugs

### DIFF
--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -93,7 +93,6 @@ if (provider) {
     provider.on("accountsChanged", async (accounts) => {
         if (accounts.length > 0) {
             displayConnectedButton();
-            return;
         } else {
             window.location.reload()
         }

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -63,6 +63,8 @@ const displayConnectedButton = async () => {
             const shortenedAccount = `${accounts[0].slice(0, 6)}...${accounts[0].slice(-4)}`;
             button.innerHTML =`Connected: ${shortenedAccount}`;
             button.className += " disabled-button";
+            button.removeEventListener("click", () => {});
+        }     
     })
 }
 

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -56,17 +56,22 @@ connectMetaMaskNav.addEventListener("click", () => {
 
 /** If we are already connected to Moonbase Alpha, show disbled button with 'Connected' text */
 const connectButtons = [connectMetaMask, connectMetaMaskNav];
+const displayConnectedButton = async () => {
+    const accounts = await ethereum.request({ method: 'eth_accounts' });
+    connectButtons.forEach((button) => {
+        if (button && accounts.length > 0){
+            const shortenedAccount = `${accounts[0].slice(0, 6)}...${accounts[0].slice(-4)}`;
+            button.innerHTML =`Connected: ${shortenedAccount}`;
+            button.className += " disabled-button";
+    })
+}
+
 const isConnectedToMoonbaseAlpha = async () => {
     const chainId = await provider.request({
         method: 'eth_chainId'
     })
     if (chainId === moonbaseAlphaChainId){
-        connectButtons.forEach((button) => {
-            if (button){
-                button.innerHTML = "Connected";
-                button.className += " disabled-button";
-            }     
-        })
+        displayConnectedButton();
     }
 }
 
@@ -80,5 +85,15 @@ if (provider) {
         // Plus, everytime the window reloads, we call isConnectedToMoonbaseAlpha again
         // and can show the correct 'Connected' or 'Connect MetaMask' button text
         window.location.reload();
+    })
+
+    /** When the account changes update the button text */
+    provider.on("accountsChanged", async (accounts) => {
+        if (accounts.length > 0) {
+            displayConnectedButton();
+            return;
+        } else {
+            window.location.reload()
+        }
     })
 }

--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -90,7 +90,7 @@ if (provider) {
     })
 
     /** When the account changes update the button text */
-    provider.on("accountsChanged", async (accounts) => {
+    provider.on("accountsChanged", (accounts) => {
         if (accounts.length > 0) {
             displayConnectedButton();
         } else {


### PR DESCRIPTION
This PR includes fixes for the Connect MetaMask buttons...
- Fixes the bug when you disconnect via MetaMask and the buttons would still show "Connected"
- Better handles multiple addresses being connected
- Fixes another bug I found where the button would be disabled but if you double clicked it, it would still open MetaMask (because the event listener was still attached 🤦‍♀️ )