### PR TITLE
remove all instances of "we want to hear from you"

### DIFF
--- a/getting-started/local-node/deploy-contract.md
+++ b/getting-started/local-node/deploy-contract.md
@@ -433,4 +433,3 @@ This will display the value before the reset transaction, the hash of the transa
 === "Web3.py"
     ![Reset Contract Web3py](/images/deploycontract/contract-reset-web3py.png)
 
---8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/local-node/send-transaction.md
+++ b/getting-started/local-node/send-transaction.md
@@ -227,4 +227,3 @@ And lastly, recheck the balance to make sure the transfer was successful. The en
 === "Web3.py"
     ![Send Tx Web3py](/images/sendtx/sendtx-web3py.png)
 
---8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/local-node/using-metamask.md
+++ b/getting-started/local-node/using-metamask.md
@@ -83,4 +83,3 @@ If you head back over to your terminal where you have your Moonbeam node running
 !!! note
     If you end up resetting your development node using the Substrate purge-chain command, you will need to reset your MetaMask genesis account using Settings -> Advanced -> Reset Account. This will clear the transaction history from your accounts and reset the nonce. Make sure you don’t erase anything that you want to keep!
  
---8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/local-node/using-remix.md
+++ b/getting-started/local-node/using-remix.md
@@ -120,4 +120,3 @@ Hit “Confirm” and, after the transaction is complete, you will see a confirm
 
 If you own the account that you sent the tokens to, you can add the token asset to verify that the transfer arrived.
 
---8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/getting-started/local-node/using-truffle.md
+++ b/getting-started/local-node/using-truffle.md
@@ -151,4 +151,3 @@ If successful, you will see deployment actions, including the address of the dep
 
 Once you have followed the [MetaMask guide](/getting-started/local-node/using-metamask/) and [Remix guide](/getting-started/local-node/using-remix/), you will be able to take the deployed contract address that is returned and load it into MetaMask or Remix.
 
---8<-- 'text/common/we-want-to-hear-from-you.md'

--- a/governance/proposals.md
+++ b/governance/proposals.md
@@ -129,6 +129,3 @@ After the transaction is submitted, you will see some confirmations on the top r
 
 ![Proposal Seconded](/images/governance/governance-proposal-9.png)
 
-## We Want to Hear From You
-
-If you have any feedback regarding sending a proposal on Moonbase Alpha or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/governance/voting.md
+++ b/governance/voting.md
@@ -209,6 +209,3 @@ In the previous example, these numbers were:
 
 In short, a heavy super-majority of aye votes is required to approve a proposal at low turnouts, but as turnout increases, it becomes a simple majority.
 
-## We Want to Hear From You
-
-If you have any feedback regarding voting a proposal on Moonbase Alpha or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/bridges/ethereum/chainbridge.md
+++ b/integrations/bridges/ethereum/chainbridge.md
@@ -18,8 +18,7 @@ This guide is broken down into two main sections. In the first part, we'll expla
     - [Transfer ERC-20 tokens](/integrations/bridges/ethereum/chainbridge/#erc-20-token-transfer)
     - [Transfer ERC-721 tokens](/integrations/bridges/ethereum/chainbridge/#erc-721-token-transfer)
     - [Generic handler](/integrations/bridges/ethereum/chainbridge/#generic-handler)
- - [Contact us](/integrations/bridges/ethereum/chainbridge/#we-want-to-hear-from-you)
-
+    
 ## How the Bridge Works
 
 ChainBridge is, at its core, a message-passing protocol. Events on a source chain are used to send a message that is routed to the destination chain. There are three main roles:
@@ -352,6 +351,4 @@ If you are interested in implementing this functionality, you can reach out dire
 ### Moonbase Alpha ChainBridge UI
 
 If you want to play around with transferring ERC20S tokens from Moonbase Alpha to Kovan or Rinkeby without having to set up the contracts in Remix, you can checkout our [Moonbase Alpha ChainBridge UI](https://moonbase-chainbridge.netlify.app/transfer).
-## We Want to Hear From You
 
-If you have any feedback regarding implementing ChainBridge on your project or any other Moonbeam-related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/integrations/debug-trace.md
+++ b/integrations/debug-trace.md
@@ -82,6 +82,3 @@ The node responds with the trace information corresponding to the filter (respon
 
 ![Trace Filter Node Running](/images/debugtrace/debugtrace-images3.png)
 
-## We Want to Hear From You
-
-If you have any feedback regarding using the Debug API or the Trace module, or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/explorers.md
+++ b/integrations/explorers.md
@@ -64,6 +64,3 @@ Subscan provides blockchain explorer capabilities for Substrate-based chains. It
 An instance of Subscan running against the Moonbase Alpha TestNet can be found in [this link](https://moonbase.subscan.io/).
 
 ![Subscan Moonbase Alpha](/images/explorers/explorers-images-5.png)
-## We Want to Hear From You
-
-If you have any feedback regarding block explorers or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/hardhat.md
+++ b/integrations/hardhat.md
@@ -268,7 +268,3 @@ We should see `5` or the value you have stored initially.
 Congratulations, you have completed the Hardhat tutorial! 🤯 🎉
 
 For more information on Hardhat, hardhat plugins, and other exciting functionality, please visit [hardhat.org](https://hardhat.org/).
-
-## We Want to Hear From You
-
-If you have any feedback regarding using Hardhat to deploy smart contracts on Moonbase Alpha or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/oracles/band-protocol.md
+++ b/integrations/oracles/band-protocol.md
@@ -239,7 +239,3 @@ We can execute this code with a node, and the following `dataQuery` output shoul
 ![Band Protocol JavaScript Library](/images/band/band-console.png)
 
 Note that compared to the request done via smart contracts, the result is given directly in the correct units.
-
-## We Want to Hear From You
-
-If you have any feedback regarding implementing Band Protocol on your project or any other Moonbeam-related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/integrations/oracles/chainlink.md
+++ b/integrations/oracles/chainlink.md
@@ -203,7 +203,3 @@ This will create an instance of the Consumer contract that you can interact with
 Note that to obtain the real price, you must account for the decimals of the price feed, available with the `decimals()` method.
 
 If there is any specific pair you want us to include, feel free to reach out to us through our [Discord server](https://discord.com/invite/PfpUATX).
-
-## We Want to Hear From You
-
-If you have any feedback regarding implementing Chainlink on your project or any other Moonbeam-related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/integrations/precompiles.md
+++ b/integrations/precompiles.md
@@ -215,6 +215,3 @@ contract ModularCheck {
 
 You can try this in [Remix](/integrations/remix/). Use the function `verify()`, passing the base, exponent, and modulus. The function will store the value in the `checkResult` variable. 
 
-## We Want to Hear From You
-
-If you have any feedback regarding Moonbase Alpha, the precompiled contracts, or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/pubsub.md
+++ b/integrations/pubsub.md
@@ -147,8 +147,5 @@ With pub/sub it is also possible to check whether a particular node you are subs
 ## Current Limitations
 The pub/sub implementation in [Frontier](https://github.com/paritytech/frontier) is still in active development. This first version allows DApp developers (or users in general) to subscribe to specific event types, but there are still some limitations. You may have noticed from previous examples that some of the fields are not showing proper information with the current version released, and that is because certain properties are yet to be supported by Frontier.
 
-## We Want to Hear From You
-If you have any feedback regarding Moonbase Alpha, event subscription, or other Moonbeam-related topics, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).
-
 
 

--- a/integrations/thegraph.md
+++ b/integrations/thegraph.md
@@ -270,7 +270,3 @@ The logs from the previous command should look similar to:
 ![The Graph deployed](/images/thegraph/thegraph-images1.png)
 
 DApps can now use the Subgraph endpoints to fetch the data indexed by The Graph protocol.
-
-## We Want to Hear From You
-
-If you have any feedback regarding creating a Subgraph in Moonbeam or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/integrations/trufflebox.md
+++ b/integrations/trufflebox.md
@@ -197,6 +197,3 @@ truffle migrate --network moonbase
 
 And that is it, you’ve used the Moonbeam Truffle box to deploy a simple ERC20 token contract in both your Moonbeam development node and Moonbase Alpha.
  
-## We Want to Hear From You
-
-If you have any feedback regarding the Moonbeam Truffle box or other Moonbeam-related topics, feel free to reach out through our official development [Discord server](https://discord.gg/PfpUATX).

--- a/integrations/wallets/mathwallet.md
+++ b/integrations/wallets/mathwallet.md
@@ -77,6 +77,3 @@ For example, in Remix, when deploying a smart contract, make sure you select the
 
 By clicking on "Accept," you are signing this transaction, and the contract will be deployed to the Moonbase Alpha TestNet.
 
-## We Want to Hear From You
-
-If you have any feedback regarding using MathWallet or any other Moonbeam related topic, feel free to reach out through our official development [Discord server](https://discord.gg/PfpUATX).

--- a/integrations/wallets/polkadotjs.md
+++ b/integrations/wallets/polkadotjs.md
@@ -66,7 +66,3 @@ After the transaction is signed using the password, Polkadot JS will display som
 ![Connect to Moonbase Alpha](/images/polkadotjs/polkadotjs-app8.png)
 
 And that is it! We are excited about being able to support H160 accounts in Polkadot JS Apps, as we believe this will greatly enhance the user experience in the Moonbeam Network and its Ethereum compatibility features.
-
-## We Want to Hear From You
-
-If you have any feedback regarding the Polkadot JS Apps, the Unified Accounts integration, or any other Moonbeam-related topics, feel free to reach out through our official development [Discord server](https://discord.gg/PfpUATX).

--- a/networks/testnet.md
+++ b/networks/testnet.md
@@ -121,6 +121,3 @@ This network is under active development. Occasionally, chain purges may be need
 
 Please take note that PureStake will not be migrating the chain state. Thus, all data stored in the blockchain will be lost when a chain purge is carried out. However, as there is no gas limit, users can easily recreate their pre-purge state.
 
-## We Want to Hear From You
-
-If you have any feedback regarding Moonbase Alpha or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/node-operators/indexers/thegraph-node.md
+++ b/node-operators/indexers/thegraph-node.md
@@ -112,7 +112,3 @@ After a while, you should see logs related to the Graph Node syncing with the la
 ![Graph Node logs](/images/thegraph/thegraphnode-images3.png)
 
 And that is it! You have a Graph Node running against the Moonbase Alpha TestNet. Feel free to adapt this example to a Moonbeam development node as well.
-
-## We Want to Hear From You
-
-If you have any feedback regarding running a Graph Node in Moonbeam or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).

--- a/node-operators/networks/collator.md
+++ b/node-operators/networks/collator.md
@@ -82,6 +82,3 @@ The following table presents some of the timings in regards to different actions
 !!! note 
     The values presented in the previous table are subject to change in future releases.
 
-## We Want to Hear From You
-
-If you have any feedback regarding running a collator or any other Moonbeam related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -469,6 +469,3 @@ This typically means that you are running an older version and will need to upgr
 
 We announce the upgrades (and corresponding chain purge) via our [Discord channel](https://discord.gg/PfpUATX) at least 24 hours in advance.
 
-## We Want to Hear From You
-
-If you have any feedback regarding running a full node or any other Moonbeam-related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/node-operators/oracles/node-chainlink.md
+++ b/node-operators/oracles/node-chainlink.md
@@ -210,6 +210,3 @@ And that is it! You have fully set up a Chainlink Oracle node that is running on
 
 To verify the Oracle is up and answering requests, follow our [using an Oracle](/integrations/oracles/chainlink/) tutorial. The main idea is to deploy a client contract that requests to the Oracle, and the Oracle writes the requested data into the contract's storage.
 
-## We Want to Hear From You
-
-If you have any feedback regarding implementing Chainlink on your project or any other Moonbeam-related topic, feel free to reach out through our official development [Discord server](https://discord.com/invite/PfpUATX).

--- a/snippets/text/common/we-want-to-hear-from-you.md
+++ b/snippets/text/common/we-want-to-hear-from-you.md
@@ -1,2 +1,0 @@
-## We Want to Hear From You
-This is a simple example, but it provides context for how you can start working with Moonbeam and trying out its Ethereum compatibility features. We are interested in hearing about your experience following the steps in this guide or trying other Ethereum-based tools with Moonbeam. Feel free to join us in the [Moonbeam Discord here](https://discord.gg/PfpUATX). We would love to hear your feedback on Moonbeam and answer any questions that you have.

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -154,7 +154,3 @@ In summary, nominators will earn rewards based on their stake of the total nomin
 From the previous example, Alice was rewarded with `0.0044` tokens after two payout rounds:
 
 ![Staking Reward Example](/images/staking/staking-stake-10.png)
-
-## We Want to Hear From You
-
-If you have any feedback regarding how to stake your tokens on Moonbase Alpha or any other Moonbeam-related topic, feel free to reach out through our official development [Discord channel](https://discord.gg/PfpUATX).


### PR DESCRIPTION
As part of the docs revamp, we're getting rid of all of the "we want to hear from you" sections in favor of a single section in the footer. This PR just removes all instances of "we want to hear from you".

This PR kind of goes hand in hand with [mkdocs PR #6 ](https://github.com/PureStake/moonbeam-mkdocs/pull/6) and can be merged really whenever but I recommend waiting until the mkdocs PR has been merged and released to production!