### PR TITLE
add custom js to expand nav items

### DIFF
--- a/js/expandNav.js
+++ b/js/expandNav.js
@@ -1,0 +1,27 @@
+document.addEventListener("DOMContentLoaded", function() {
+  load_navpane();
+});
+
+function load_navpane() {
+  var width = window.innerWidth;
+  if (width <= 1200) {
+      return;
+  }
+
+  var nav = document.getElementsByClassName("md-nav");
+  for(var i = 0; i < nav.length; i++) {
+      if (typeof nav.item(i).style === "undefined") {
+          continue;
+      }
+
+      if (nav.item(i).getAttribute("data-md-level") && nav.item(i).getAttribute("data-md-component")) {
+          nav.item(i).style.display = 'block';
+          nav.item(i).style.overflow = 'visible';
+      }
+  }
+
+  var nav = document.getElementsByClassName("md-nav__toggle");
+  for(var i = 0; i < nav.length; i++) {
+     nav.item(i).checked = true;
+  }
+}


### PR DESCRIPTION
The mkdocs one-liner is not working, it's not due to `awesome-pages` plugin, it's not due to `extra_javascript` field... I didn't want to spend a whole lot of time on this so I am ultimately not sure why it isn't working. In my research I came across [this issue](https://github.com/squidfunk/mkdocs-material/issues/767) in the mkdocs-material repo. Before `navigation.expand` was a thing, someone had written some custom javascript to handle it, which actually works. So I just decided to run with that... there is sometimes a bit of a lag in the expansion but I don't think it's bothersome, but let me know if you think otherwise! 

This goes hand in hand with [mkdocs PR #7](https://github.com/PureStake/moonbeam-mkdocs/pull/7)