### PR TITLE
update awesome pages - arrange has been deprecated

### DIFF
--- a/.pages
+++ b/.pages
@@ -1,4 +1,4 @@
-arrange:
+nav:
   - README.md
   - overview
   - getting-started

--- a/getting-started/.pages
+++ b/getting-started/.pages
@@ -1,4 +1,4 @@
 title: Getting Started
-arrange:
+nav:
  - local-node
  - testnet

--- a/getting-started/local-node/.pages
+++ b/getting-started/local-node/.pages
@@ -1,5 +1,5 @@
 title: Local Node
-arrange:
+nav:
   - setting-up-a-node.md
   - using-metamask.md
   - using-remix.md

--- a/getting-started/testnet/.pages
+++ b/getting-started/testnet/.pages
@@ -1,5 +1,5 @@
 title: TestNet
-arrange:
+nav:
   - connect.md
   - faucet.md
   - metamask.md

--- a/governance/.pages
+++ b/governance/.pages
@@ -1,5 +1,5 @@
 title: Governance
-arrange:
+nav:
   - overview.md
   - proposals.md
   - voting.md

--- a/integrations/.pages
+++ b/integrations/.pages
@@ -1,5 +1,5 @@
 title: Integrations
-arrange:
+nav:
   - bridges
   - ethlibraries
   - openzeppelin

--- a/integrations/bridges/.pages
+++ b/integrations/bridges/.pages
@@ -1,4 +1,4 @@
 title: Bridges
 hide: false
-arrange:
+nav:
   - ethereum

--- a/integrations/bridges/ethereum/.pages
+++ b/integrations/bridges/ethereum/.pages
@@ -1,4 +1,4 @@
 title: Ethereum
 hide: false
-arrange:
+nav:
   - chainbridge.md

--- a/integrations/ethlibraries/.pages
+++ b/integrations/ethlibraries/.pages
@@ -1,4 +1,4 @@
 title: Eth Libraries
-arrange:
+nav:
   - etherjs.md
   - web3js.md

--- a/integrations/openzeppelin/.pages
+++ b/integrations/openzeppelin/.pages
@@ -1,6 +1,6 @@
 title: Open Zeppelin
 hide: false
-arrange:
+nav:
   - overview.md
   - contracts.md
   - defender.md

--- a/integrations/oracles/.pages
+++ b/integrations/oracles/.pages
@@ -1,5 +1,5 @@
 title: Oracles
 hide: false
-arrange:
+nav:
   - band-protocol.md
   - chainlink.md

--- a/integrations/wallets/.pages
+++ b/integrations/wallets/.pages
@@ -1,5 +1,5 @@
 title: Wallets
-arrange:
+nav:
   - mathwallet.md
   - metamask.md
   - polkadotjs.md

--- a/learn/.pages
+++ b/learn/.pages
@@ -1,5 +1,5 @@
 title: Learn
-arrange:
+nav:
   - technology.md
   - eth-compatibility.md
   - unified-accounts.md

--- a/networks/.pages
+++ b/networks/.pages
@@ -1,4 +1,4 @@
 title: Networks
-arrange:
+nav:
   - overview.md 
   - testnet.md

--- a/node-operators/.pages
+++ b/node-operators/.pages
@@ -1,5 +1,5 @@
 title: Node Operators
 hide: false
-arrange:
+nav:
   - networks
   - oracles

--- a/node-operators/networks/.pages
+++ b/node-operators/networks/.pages
@@ -1,6 +1,6 @@
 title: Networks
 hide: false
-arrange:
+nav:
   - full-node.md
   - collator.md
   - telemetry.md

--- a/node-operators/oracles/.pages
+++ b/node-operators/oracles/.pages
@@ -1,4 +1,4 @@
 title: Oracles
 hide: false
-arrange:
+nav:
   - node-chainlink.md

--- a/resources/.pages
+++ b/resources/.pages
@@ -1,5 +1,5 @@
 title: Resources
-arrange:
+nav:
   - code.md
   - links.md
   - roadmap.md

--- a/staking/.pages
+++ b/staking/.pages
@@ -1,4 +1,4 @@
 title: Staking
-arrange:
+nav:
   - overview.md
   - stake.md


### PR DESCRIPTION
awesome-pages has deprecated `arrange` and recommends using `nav` instead: https://github.com/lukasgeiter/mkdocs-awesome-pages-plugin#arrange-pages

these changes are a part of the docs revamp but can be separated and taken care of now 🙂 

this must be merged in after the [`moonbeam-project-directory` PR](https://github.com/PureStake/moonbeam-project-directory/pull/10) does