### PR TITLE
cleanup rpc flags

### DIFF
--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -116,8 +116,6 @@ Now, execute the docker run command. Note that you have to:
     docker run -p {{ networks.parachain.rpc }}:{{ networks.parachain.rpc }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} -v "{{ networks.moonbase.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
-    --ws-external \
-    --rpc-external \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -154,8 +152,6 @@ Now, execute the docker run command. Note that you have to:
     docker run -p {{ networks.parachain.rpc }}:{{ networks.parachain.rpc }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} -v "{{ networks.moonbase.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
-    --ws-external \
-    --rpc-external \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -289,7 +285,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --ws-port {{ networks.parachain.ws }} \
          --pruning=archive \
          --state-cache-size 1 \
-         --log rpc=info \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \
          --name "YOUR-NODE-NAME" \
@@ -326,7 +321,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --ws-port {{ networks.parachain.ws }} \
          --pruning=archive \
          --state-cache-size 1 \
-         --log rpc=info \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \
          --name "YOUR-NODE-NAME" \

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -99,7 +99,6 @@ Now, execute the docker run command. Note that you have to:
     docker run --network="host" -v "{{ networks.moonbase.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
-    --rpc-cors all \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -119,7 +118,6 @@ Now, execute the docker run command. Note that you have to:
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
     --ws-external \
     --rpc-external \
-    --rpc-cors all \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -138,7 +136,6 @@ Now, execute the docker run command. Note that you have to:
     docker run --network="host" -v "{{ networks.moonbase.node_directory }}:/data" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
-    --rpc-cors all \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -159,7 +156,6 @@ Now, execute the docker run command. Note that you have to:
     purestake/moonbeam:{{ networks.moonbase.parachain_docker_tag }} \
     --ws-external \
     --rpc-external \
-    --rpc-cors all \
     --base-path=/data \
     --chain alphanet \
     --name="YOUR-NODE-NAME" \
@@ -293,10 +289,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --ws-port {{ networks.parachain.ws }} \
          --pruning=archive \
          --state-cache-size 1 \
-         --unsafe-rpc-external \
-         --unsafe-ws-external \
-         --rpc-methods=Safe \
-         --rpc-cors all \
          --log rpc=info \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \
@@ -334,10 +326,6 @@ The next step is to create the systemd configuration file. Note that you have to
          --ws-port {{ networks.parachain.ws }} \
          --pruning=archive \
          --state-cache-size 1 \
-         --unsafe-rpc-external \
-         --unsafe-ws-external \
-         --rpc-methods=Safe \
-         --rpc-cors all \
          --log rpc=info \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain alphanet \

--- a/node-operators/networks/full-node.md
+++ b/node-operators/networks/full-node.md
@@ -170,12 +170,15 @@ Once Docker pulls the necessary images, your Moonbase Alpha full node will start
 ![Full Node Starting](/images/fullnode/fullnode-docker1.png)
 
 !!! note
+    If you want to run an RPC endpoint, to connect polkadot.js.org, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`.  
+
+!!! note
     If you are having issues with the default telemetry, you can add the flag `--no-telemetry` to run the full node without telemetry activated.
 
 !!! note
     You can specify a custom Prometheus port with the `--prometheus-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
 
-The command above will enable all exposed ports, including the P2P, RPC, and Prometheus (telemetry) ports. This command is compatible to use with the Gantree Node Watchdog telemetry. If you want to expose specific ports, enable those on the Docker run command line as shown below. However, doing so will block the Gantree Node Watchdog (telemetry) container from accessing the moonbeam container, so don't do this when running a collator unless you understand [docker networking](https://docs.docker.com/network/).
+The command above will enable all exposed ports required for basic operation, including the P2P, and Prometheus (telemetry) ports. This command is compatible to use with the Gantree Node Watchdog telemetry. If you want to expose specific ports, enable those on the Docker run command line as shown below. However, doing so will block the Gantree Node Watchdog (telemetry) container from accessing the moonbeam container, so don't do this when running a collator unless you understand [docker networking](https://docs.docker.com/network/).
 
 ```
 docker run -p {{ networks.relay_chain.p2p }}:{{ networks.relay_chain.p2p }} -p {{ networks.parachain.p2p }}:{{ networks.parachain.p2p }} -p {{ networks.parachain.rpc }}:{{ networks.parachain.rpc }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} #rest of code goes here


### PR DESCRIPTION
The RPC flags were inconsistent, so I defaulted to no external RPC, and RPC methods = Auto (the default) which will be safe if externally expose and unsafe if not.  

We can't create a template that is good for everyone, so a default base secure template will be best, and we can help out RPC providers if they need additional help.  