### PR TITLE
Fixes Broken Sectional Links in Setting Up A Node Page

### DIFF
--- a/getting-started/local-node/setting-up-a-node.md
+++ b/getting-started/local-node/setting-up-a-node.md
@@ -64,7 +64,7 @@ If successful, you should see an output showing an idle state waiting for blocks
 
 ![Docker - output shows blocks being produced](/images/setting-up-a-node/setting-up-node-2.png)
 
-For more information on some of the flags and options used in the example, check out [Common Flags and Options](#common-flags-and-options). If you want to see a complete list of all of the flags, options, and subcommands, open the help menu by running:
+For more information on some of the flags and options used in the example, check out [Common Flags and Options](#common-commands-flags-and-options). If you want to see a complete list of all of the flags, options, and subcommands, open the help menu by running:
 
 ```
 docker run --rm --name {{ networks.development.container_name }} \
@@ -126,7 +126,7 @@ You should see an output that looks like the following, showing an idle state wa
 
 ![Output shows blocks being produced](/images/setting-up-a-node/setting-up-node-4.png)
 
-For more information on some of the flags and options used in the example, check out [Common Flags and Options](#common-flags-and-options). If you want to see a complete list of all of the flags, options, and subcommands, open the help menu by running:
+For more information on some of the flags and options used in the example, check out [Common Flags and Options](#common-commands-flags-and-options). If you want to see a complete list of all of the flags, options, and subcommands, open the help menu by running:
 
 ```
 ./target/release/moonbeam --help


### PR DESCRIPTION
Issue is related to mkdocs TOC extension slugifying headers that have been changed, creating a mismatch between the newly generated sectional IDs, and the existing URL's in the document. 

Ran across this while looking into a related issue in the Chinese docs: https://github.com/PureStake/moonbeam-docs-cn/pull/5