### PR TITLE
Update Parachain Release Version and Sha256 Hash

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -11,8 +11,8 @@ networks:
     chain_id: 1287
     chain_spec: alphanet
     block_explorer: https://moonbase-blockscout.testnet.moonbeam.network/
-    parachain_release_tag: v0.9.1
-    parachain_sha256sum: de4cbbd849b70b2215d5fc9b67f5841d985c6bad496940a2eb3f15534e6f735f
+    parachain_release_tag: v0.10.0
+    parachain_sha256sum: a3da6aa16a9c36c38f58d4d8164b0e44b69dee1528f273a7e18458c745233569
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data

--- a/variables.yml
+++ b/variables.yml
@@ -115,8 +115,8 @@ networks:
     wss_url: wss://wss.moonriver.moonbeam.network
     chain_id: 1285
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.9.1
-    parachain_sha256sum: de4cbbd849b70b2215d5fc9b67f5841d985c6bad496940a2eb3f15534e6f735f
+    parachain_release_tag: v0.10.0
+    parachain_sha256sum: a3da6aa16a9c36c38f58d4d8164b0e44b69dee1528f273a7e18458c745233569
     chain_spec: moonriver
     block_explorer: https://blockscout.moonriver.moonbeam.network/
     binary_name: moonbeam


### PR DESCRIPTION
Normally I would just merge this in but didn't want to impact any conflicting changes. This PR updates the version tag and the SHA256 hash for the latest binary of Moonbeam (v0.10.0)