### PR TITLE
Adds a Quick Reference section to Staking/Overview

### DIFF
--- a/networks/moonriver.md
+++ b/networks/moonriver.md
@@ -50,7 +50,6 @@ Some important variables/configurations to note include:
     |             Variable             |                                                     Value                                                     |
     |:--------------------------------:|:-------------------------------------------------------------------------------------------------------------:|
     |     Minimum nomination stake     |                           {{ networks.moonriver.staking.    min_nom_stake }} tokens                           |
-    |        Minimum nomination        |                           {{ networks.moonriver.staking.    min_nom_amount}} tokens                           |
     | Maximum nominators per collators |                             {{ networks.moonriver.staking.    max_nom_per_col }}                              |
     | Maximum collators per nominator  |                             {{ networks.moonriver.staking.    max_col_per_nom }}                              |
     |              Round               | {{ networks.moonriver.staking.round_blocks }} blocks ({{     networks.moonriver.staking.round_hours }} hours) |

--- a/snippets/text/moonriver-launch/post-launch.md
+++ b/snippets/text/moonriver-launch/post-launch.md
@@ -1,0 +1,1 @@
+The Moonriver network has completed its launch process, and the staking feature is open to users that wish to participate. You can start interacting with staking functions through this [dashboard](https://apps.moonbeam.network/moonriver). 

--- a/snippets/text/moonriver-launch/post-launch.md
+++ b/snippets/text/moonriver-launch/post-launch.md
@@ -1,1 +1,0 @@
-The Moonriver network has completed its launch process, and the staking feature is open to users that wish to participate. 

--- a/snippets/text/moonriver-launch/post-launch.md
+++ b/snippets/text/moonriver-launch/post-launch.md
@@ -1,1 +1,1 @@
-The Moonriver network has completed its launch process, and the staking feature is open to users that wish to participate. You can start interacting with staking functions through this [dashboard](https://apps.moonbeam.network/moonriver). 
+The Moonriver network has completed its launch process, and the staking feature is open to users that wish to participate. 

--- a/snippets/text/moonriver-launch/staking-phase-4.md
+++ b/snippets/text/moonriver-launch/staking-phase-4.md
@@ -1,1 +1,0 @@
-Staking is currently restricted on Moonriver, but in Phase 4 of the [Moonriver network launch](https://moonbeam.network/networks/moonriver/launch/) restrictions will be removed so all users can participate in the staking system.

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -30,11 +30,11 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Bonding duration** — nomination takes effect in the next round (funds are withdrawn immediately)
     - **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds
     - **Reward payout time** — {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds. Rewards are distributed automatically to the free balance
-    - **Collator commission** — fixed at {{ networks.moonriver.staking.collator_reward_inflation }}% of the annual inflation, set to {{ networks.moonriver.treasury.total_annual_inflation }}% per year. Not related to the nominators reward pool
+    - **Collator commission** — fixed at {{ networks.moonriver.staking.collator_reward_inflation }}% of the annual inflation ({{ networks.moonriver.total_annual_inflation }}%). Not related to the nominators reward pool
     - **Nominators reward pool** — {{ networks.moonriver.staking.nominator_reward_inflation }}% of the annual inflation
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
-    - **Collator information** — list of collators: [Moonriver Subscan](https://moonriver.subscan.io/validator). Collator data for the last two rounds: Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+    - **Collator information** — list of collators: [Moonriver Subscan](https://moonriver.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
     - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
 
 === "Moonbase Alpha" 
@@ -46,11 +46,11 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Bonding duration** — nomination takes effect in the next round (funds are withdrawn immediately)
     - **Unbonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds
     - **Reward payout time** — {{ networks.moonbase.collator_timings.rewards_payouts.rounds }} rounds. Rewards are distributed automatically to the free balance
-    - **Collator commission** — fixed at {{ networks.moonbase.staking.collator_reward_inflation }}% of the annual  inflation, set to {{ networks.moonbase.treasury.total_annual_inflation }}% per year. Not related to the nominators reward pool
+    - **Collator commission** — fixed at {{ networks.moonbase.staking.collator_reward_inflation }}% of the annual  inflation ({{ networks.moonriver.total_annual_inflation }}%). Not related to the nominators reward pool
     - **Nominators reward pool** — {{ networks.moonbase.staking.nominator_reward_inflation }}% of the annual  inflation
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
-    - **Collator information** — list of collators: [Moonriver Subscan](https://moonbase.subscan.io/validator). Collator data for the last two rounds: Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+    - **Collator information** — list of collators: [Moonriver Subscan](https://moonbase.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
     - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonbase-alpha)
 
 ## Reward Distribution {: #reward-distribution } 

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -85,6 +85,6 @@ Where `amount_due` is the corresponding inflation being distributed in a specifi
 
 In the Moonbase Alpha TestNet, token holders can stake and earn rewards (to get familiar with the system as the token doesn't have any actual value).
 
-To do so, you can check [this guide](/staking/stake/).
-
 --8<-- 'text/moonriver-launch/post-launch.md'
+
+You can start interacting with staking functions through this [dashboard](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](/staking/stake/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -15,6 +15,21 @@ The collators' set (nodes that produce blocks) are selected based on their stake
 
 Collators (and token holders if they nominate) have a stake in the network. The top N collators by staked amount are chosen to produce blocks with a valid set of transactions, where N is a configurable parameter. Part of each block reward goes to the collator that produced the block, who then shares it with the nominators considering their percental contributions towards the collator's staked. In such a way, network members are incentivized to stake tokens to improve the overall security.
 
+## Quick Reference {: #quick-reference }
+
+* Minimum Nomination Amount: {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
+* Max Eligible Nominators Per Collator: Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
+* Bonding Duration: {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
+* Unbonding Duration: {{ networks.moonriver.staking.bond_lock }} rounds 
+* Reward Payout Time: Rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
+* Aggregate Nominator Rewards: 50% of total inflation
+* Nominator Rewards: Variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes; [More Information](/staking/overview/#reward-distribution)
+* Collator Commission: Fixed at 20% of total inflation, separate from the nominator reward pool
+* Slashing: No slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
+* Collator Information: [Link1](https://moonriver.subscan.io/validator) [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
+* Managing Staking and Nomination Related Actions: [Link](https://apps.moonbeam.network/moonriver)
+
+
 ## General Definitions {: #general-definitions } 
 
 --8<-- 'text/staking/staking-definitions.md'
@@ -41,20 +56,6 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
 
-
-## Quick Reference {: #quick-reference }
-
-* Minimum Nomination Amount: {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
-* Max Eligible Nominators Per Collator: Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
-* Bonding Period: The start of the next round from the time of bonding to start earning rewards
-* Unbonding Period: {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
-* Reward Distribution Wait Period: 2 rounds after rewards are earned
-* Aggregate Nominator Rewards: 50% of total inflation
-* Nominator Yield: Variable, the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes; [see more details](/staking/overview/#reward-distribution)
-* Collator Commission: Fixed at 20% of total inflation, separate from the nominator reward pool
-* Slashing: No slashing currently (can be changed with governance). Collator rewards are paid as part of produced blocks.  So poorly performing Collators that don’t produce blocks will pay out less or no rewards
-* Active Collators and the Nominations: [Follow Link](https://moonriver.subscan.io/validator)
-* Managing Staking and Nomination Related Actions: [Follow Link](https://apps.moonbeam.network/moonriver)
 
 ## Reward Distribution {: #reward-distribution } 
 

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -87,4 +87,4 @@ In the Moonbase Alpha TestNet, token holders can stake and earn rewards (to get 
 
 To do so, you can check [this guide](/staking/stake/).
 
---8<-- 'text/moonriver-launch/staking-phase-4.md'
+--8<-- 'text/moonriver-launch/post-launch.md'

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -41,6 +41,21 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
 
+
+## Quick Reference {: quick-reference}
+
+* Minimum Nomination Amount: {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
+* Max Eligible Nominators Per Collator: Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
+* Bonding Period: The start of the next round from the time of bonding to start earning rewards
+* Unbonding Period: {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
+* Reward Distribution Wait Period: 2 rounds after rewards are earned
+* Aggregate Nominator Rewards: 50% of total inflation
+* Nominator Yield: Variable, the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes; [see more details](/staking/overview/#reward-distribution)
+* Collator Commission: Fixed at 20% of total inflation, separate from the nominator reward pool
+* Slashing: No slashing currently (can be changed with governance). Collator rewards are paid as part of produced blocks.  So poorly performing Collators that don’t produce blocks will pay out less or no rewards
+* Active Collators and the Nominations: [Follow Link](https://moonriver.subscan.io/validator)
+* Managing Staking and Nomination Related Actions: [Follow Link](https://apps.moonbeam.network/moonriver)
+
 ## Reward Distribution {: #reward-distribution } 
 
 Collators are rewarded at the end of every round ({{ networks.moonbase.staking.round_blocks }} blocks) for their work from {{ networks.moonbase.staking.bond_lock }} rounds ago.

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -17,17 +17,17 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 
 ## Quick Reference {: #quick-reference }
 
-- **Minimum Nomination Amount** — {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
-- **Max Eligible Nominators Per Collator** — Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
-- **Bonding Duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
-- **Unbonding Duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
-- **Reward Payout Time** — Rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
-- **Aggregate Nominator Rewards** — 50% of total inflation
-- **Nominator Rewards** — Variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
-- **Collator Commission** — Fixed at 20% of total inflation, separate from the nominator reward pool
-- **Slashing** — No slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-- **Collator Information** — [Link1](https://moonriver.subscan.io/validator), [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
-- **Managing Staking and Nomination Related Actions** — [Link](https://apps.moonbeam.network/moonriver)
+- **Minimum nomination amount** — {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
+- **Max eligible nominators per collator** — top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
+- **Bonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
+- **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
+- **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
+- **Aggregate nominator rewards** — 50% of total inflation
+- **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
+- **Collator commission** — fixed at 20% of total inflation, separate from the nominator reward pool
+- **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
+- **Collator information** — [Link1](https://moonriver.subscan.io/validator), [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
+- **Managing staking and nomination related actions** — [Link](https://apps.moonbeam.network/moonriver)
 
 
 ## General Definitions {: #general-definitions } 

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -42,7 +42,7 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
 
 
-## Quick Reference {: quick-reference}
+## Quick Reference {: #quick-reference }
 
 * Minimum Nomination Amount: {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
 * Max Eligible Nominators Per Collator: Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -26,8 +26,8 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 - **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
 - **Collator commission** — fixed at 20% of total inflation, separate from the nominator reward pool
 - **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-- **Collator information** — [Link1](https://moonriver.subscan.io/validator), [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
-- **Managing staking and nomination related actions** — [Link](https://apps.moonbeam.network/moonriver)
+- **Collator information** — [list of validators on the Moonriver Subscan](https://moonriver.subscan.io/validator), [collator data on the Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+- **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
 
 
 ## General Definitions {: #general-definitions } 

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -17,17 +17,17 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 
 ## Quick Reference {: #quick-reference }
 
-* Minimum Nomination Amount: {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
-* Max Eligible Nominators Per Collator: Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
-* Bonding Duration: {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
-* Unbonding Duration: {{ networks.moonriver.staking.bond_lock }} rounds 
-* Reward Payout Time: Rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
-* Aggregate Nominator Rewards: 50% of total inflation
-* Nominator Rewards: Variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes; [More Information](/staking/overview/#reward-distribution)
-* Collator Commission: Fixed at 20% of total inflation, separate from the nominator reward pool
-* Slashing: No slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-* Collator Information: [Link1](https://moonriver.subscan.io/validator) [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
-* Managing Staking and Nomination Related Actions: [Link](https://apps.moonbeam.network/moonriver)
+- **Minimum Nomination Amount** — {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
+- **Max Eligible Nominators Per Collator** — Top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
+- **Bonding Duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
+- **Unbonding Duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
+- **Reward Payout Time** — Rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
+- **Aggregate Nominator Rewards** — 50% of total inflation
+- **Nominator Rewards** — Variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
+- **Collator Commission** — Fixed at 20% of total inflation, separate from the nominator reward pool
+- **Slashing** — No slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
+- **Collator Information** — [Link1](https://moonriver.subscan.io/validator), [Link2](https://moonbeam-explorer.netlify.app/stats/miners/)
+- **Managing Staking and Nomination Related Actions** — [Link](https://apps.moonbeam.network/moonriver)
 
 
 ## General Definitions {: #general-definitions } 
@@ -85,6 +85,4 @@ Where `amount_due` is the corresponding inflation being distributed in a specifi
 
 In the Moonbase Alpha TestNet, token holders can stake and earn rewards (to get familiar with the system as the token doesn't have any actual value).
 
---8<-- 'text/moonriver-launch/post-launch.md'
-
-You can start interacting with staking functions through this [dashboard](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](/staking/stake/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).
+You can start interacting with staking functions on Moonbase Alpha or Moonriver through this [dashboard](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -81,4 +81,4 @@ Where `amount_due` is the corresponding inflation being distributed in a specifi
 
 In the Moonbase Alpha TestNet, token holders can stake and earn rewards (to get familiar with the system as the token doesn't have any actual value).
 
-You can start interacting with staking functions on Moonriver and Moonbase Alphathrough the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).
+You can start interacting with staking functions on Moonriver and Moonbase Alpha through the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -15,62 +15,43 @@ The collators' set (nodes that produce blocks) are selected based on their stake
 
 Collators (and token holders if they nominate) have a stake in the network. The top N collators by staked amount are chosen to produce blocks with a valid set of transactions, where N is a configurable parameter. Part of each block reward goes to the collator that produced the block, who then shares it with the nominators considering their percental contributions towards the collator's staked. In such a way, network members are incentivized to stake tokens to improve the overall security.
 
+## General Definitions {: #general-definitions } 
+
+--8<-- 'text/staking/staking-definitions.md'
+
 ## Quick Reference {: #quick-reference }
 
 === "Moonriver" 
 
     - **Minimum nomination amount** — {{ networks.moonriver.staking.min_nom_stake }} MOVR
-    - **Max eligible nominators per collator** — top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
-    - **Bonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately {{ networks.moonriver.staking.round_hours }} hour)
-    - **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
-    - **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
-    - **Aggregate nominator rewards** — {{ networks.moonriver.staking.nominator_reward_as_percent_of_inflation }}% of total inflation, which is set to {{ networks.moonriver.treasury.total_annual_inflation }}% per year
-    - **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
-    - **Collator commission** — fixed at {{ networks.moonriver.staking.collator_reward_as_percent_of_inflation }}% of total inflation, set to a {{ networks.moonriver.treasury.total_annual_inflation }}% annual total inflation rate, separate from the nominator reward pool
-    - **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-    - **Collator information** — [list of validators on the Moonriver Subscan](https://moonriver.subscan.io/validator), [collator data on the Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
-    - **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
+    - **Round duration** — {{ networks.moonriver.staking.round_blocks }} blocks, time per round is approximately {{ networks.moonriver.staking.round_hours }} hour
+    - **Max eligible nominators per collator** — for a given round, only the top {{ networks.moonriver.staking.max_nom_per_col }} nominators by staked amount are eligible for staking rewards
+    - **Max collators per nominator** — a nominator can nominated {{ networks.moonriver.staking.max_col_per_nom }} different collators
+    - **Bonding duration** — nomination takes effect in the next round (funds are withdrawn immediately)
+    - **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds
+    - **Reward payout time** — {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds. Rewards are distributed automatically to the free balance
+    - **Collator commission** — fixed at {{ networks.moonriver.staking.collator_reward_inflation }}% of the annual inflation, set to {{ networks.moonriver.treasury.total_annual_inflation }}% per year. Not related to the nominators reward pool
+    - **Nominators reward pool** — {{ networks.moonriver.staking.nominator_reward_inflation }}% of the annual inflation
+    - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
+    - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
+    - **Collator information** — list of collators: [Moonriver Subscan](https://moonriver.subscan.io/validator). Collator data for the last two rounds: Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+    - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
 
 === "Moonbase Alpha" 
 
     - **Minimum nomination amount** — {{ networks.moonbase.staking.min_nom_stake }} DEV
-    - **Max eligible nominators per collator** — top {{ networks.moonbase.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonbase.staking.max_nom_per_col }} do not receive any rewards)
-    - **Bonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds ({{ networks.moonbase.staking.round_blocks }} blocks/round, time per round is approximately {{ networks.moonbase.staking.round_hours }} hour)
-    - **Unbonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds 
-    - **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonbase.collator_timings.rewards_payouts.rounds }} rounds after they are earned
-    - **Aggregate nominator rewards** — {{ networks.moonbase.staking.nominator_reward_as_percent_of_inflation }}% of total inflation, which is set to {{ networks.moonbase.treasury.total_annual_inflation }}% per year
-    - **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
-    - **Collator commission** — fixed at {{ networks.moonbase.staking.collator_reward_as_percent_of_inflation }}% of total inflation, set to a {{ networks.moonbase.treasury.total_annual_inflation }}% annual total inflation rate, separate from the nominator reward pool
-    - **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-    - **Collator information** — [list of validators on the Moonbase Alpha Subscan](https://moonbase.subscan.io/validator)
-    - **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonbase-alpha)
-
-## General Definitions {: #general-definitions } 
-
---8<-- 'text/staking/staking-definitions.md'
-
-=== "Moonriver"
-
-    |             Variable             |  |                                                   Value                                                   |
-    |:--------------------------------:|::|:---------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                           {{ networks.moonriver.staking.min_nom_stake }} MOVR                             |
-    |        Minimum nomination        |  |                           {{ networks.moonriver.staking.min_nom_amount}} MOVR                             |
-    | Maximum nominators per collators |  |                             {{ networks.moonriver.staking.max_nom_per_col }}                              |
-    | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |
-    |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
-    |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
-
-=== "Moonbase Alpha"
-
-    |             Variable             |  |                                                  Value                                                  |
-    |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                          {{ networks.moonbase.staking.min_nom_stake }} DEV                              |
-    |        Minimum nomination        |  |                          {{ networks.moonbase.staking.min_nom_amount}} DEV                              |
-    | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
-    | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
-    |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
-    |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
-
+    - **Round duration** — {{ networks.moonbase.staking.round_blocks }} blocks, time per round is approximately {{ networks.moonbase.staking.round_hours }} hour
+    - **Max eligible nominators per collator** — for a given round, only the top {{ networks.moonbase.staking.max_nom_per_col }} nominators by staked amount are eligible for staking rewards
+    - **Max collators per nominator** — a nominator can nominated {{ networks.moonbase.staking.max_col_per_nom }} different collators
+    - **Bonding duration** — nomination takes effect in the next round (funds are withdrawn immediately)
+    - **Unbonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds
+    - **Reward payout time** — {{ networks.moonbase.collator_timings.rewards_payouts.rounds }} rounds. Rewards are distributed automatically to the free balance
+    - **Collator commission** — fixed at {{ networks.moonbase.staking.collator_reward_inflation }}% of the annual  inflation, set to {{ networks.moonbase.treasury.total_annual_inflation }}% per year. Not related to the nominators reward pool
+    - **Nominators reward pool** — {{ networks.moonbase.staking.nominator_reward_inflation }}% of the annual  inflation
+    - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
+    - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
+    - **Collator information** — list of collators: [Moonriver Subscan](https://moonbase.subscan.io/validator). Collator data for the last two rounds: Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+    - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonbase-alpha)
 
 ## Reward Distribution {: #reward-distribution } 
 
@@ -100,4 +81,4 @@ Where `amount_due` is the corresponding inflation being distributed in a specifi
 
 In the Moonbase Alpha TestNet, token holders can stake and earn rewards (to get familiar with the system as the token doesn't have any actual value).
 
-You can start interacting with staking functions on Moonbase Alpha or Moonriver through this [dashboard](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).
+You can start interacting with staking functions on Moonriver and Moonbase Alphathrough the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -17,33 +17,37 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 
 ## Quick Reference {: #quick-reference }
 
-- **Minimum nomination amount** — {{ networks.moonbase.staking.min_nom_stake }} MOVR/DEV
-- **Max eligible nominators per collator** — top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
-- **Bonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately 1 hour)
-- **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
-- **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
-- **Aggregate nominator rewards** — 50% of total inflation
-- **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
-- **Collator commission** — fixed at 20% of total inflation, separate from the nominator reward pool
-- **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
-- **Collator information** — [list of validators on the Moonriver Subscan](https://moonriver.subscan.io/validator), [collator data on the Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
-- **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
+=== "Moonriver" 
 
+    - **Minimum nomination amount** — {{ networks.moonriver.staking.min_nom_stake }} MOVR
+    - **Max eligible nominators per collator** — top {{ networks.moonriver.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonriver.staking.max_nom_per_col }} do not receive any rewards)
+    - **Bonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds ({{ networks.moonriver.staking.round_blocks }} blocks/round, time per round is approximately {{ networks.moonriver.staking.round_hours }} hour)
+    - **Unbonding duration** — {{ networks.moonriver.staking.bond_lock }} rounds 
+    - **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonriver.collator_timings.rewards_payouts.rounds }} rounds after they are earned
+    - **Aggregate nominator rewards** — {{ networks.moonriver.staking.nominator_reward_as_percent_of_inflation }}% of total inflation, which is set to {{ networks.moonriver.treasury.total_annual_inflation }}% per year
+    - **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
+    - **Collator commission** — fixed at {{ networks.moonriver.staking.collator_reward_as_percent_of_inflation }}% of total inflation, set to a {{ networks.moonriver.treasury.total_annual_inflation }}% annual total inflation rate, separate from the nominator reward pool
+    - **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
+    - **Collator information** — [list of validators on the Moonriver Subscan](https://moonriver.subscan.io/validator), [collator data on the Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners/)
+    - **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
+
+=== "Moonbase Alpha" 
+
+    - **Minimum nomination amount** — {{ networks.moonbase.staking.min_nom_stake }} DEV
+    - **Max eligible nominators per collator** — top {{ networks.moonbase.staking.max_nom_per_col }} nominators by size of stake per collator are eligible for staking rewards (nominators not in the top {{ networks.moonbase.staking.max_nom_per_col }} do not receive any rewards)
+    - **Bonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds ({{ networks.moonbase.staking.round_blocks }} blocks/round, time per round is approximately {{ networks.moonbase.staking.round_hours }} hour)
+    - **Unbonding duration** — {{ networks.moonbase.staking.bond_lock }} rounds 
+    - **Reward payout time** — rewards are distributed automatically to the free balance {{ networks.moonbase.collator_timings.rewards_payouts.rounds }} rounds after they are earned
+    - **Aggregate nominator rewards** — {{ networks.moonbase.staking.nominator_reward_as_percent_of_inflation }}% of total inflation, which is set to {{ networks.moonbase.treasury.total_annual_inflation }}% per year
+    - **Nominator rewards** — variable; it's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([More Information](/staking/overview/#reward-distribution))
+    - **Collator commission** — fixed at {{ networks.moonbase.staking.collator_reward_as_percent_of_inflation }}% of total inflation, set to a {{ networks.moonbase.treasury.total_annual_inflation }}% annual total inflation rate, separate from the nominator reward pool
+    - **Slashing** — no slashing currently (can be changed with governance); collator rewards are paid as part of produced blocks, so offline or poorly performing collators that don’t produce blocks will pay out less or no rewards
+    - **Collator information** — [list of validators on the Moonbase Alpha Subscan](https://moonbase.subscan.io/validator)
+    - **Managing staking and nomination related actions** — [the Moonbeam Network dApp](https://apps.moonbeam.network/moonbase-alpha)
 
 ## General Definitions {: #general-definitions } 
 
 --8<-- 'text/staking/staking-definitions.md'
-
-=== "Moonbase Alpha"
-
-    |             Variable             |  |                                                  Value                                                  |
-    |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                          {{ networks.moonbase.staking.min_nom_stake }} DEV                              |
-    |        Minimum nomination        |  |                          {{ networks.moonbase.staking.min_nom_amount}} DEV                              |
-    | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
-    | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
-    |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
-    |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
 
 === "Moonriver"
 
@@ -55,6 +59,17 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
+
+=== "Moonbase Alpha"
+
+    |             Variable             |  |                                                  Value                                                  |
+    |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
+    |     Minimum nomination stake     |  |                          {{ networks.moonbase.staking.min_nom_stake }} DEV                              |
+    |        Minimum nomination        |  |                          {{ networks.moonbase.staking.min_nom_amount}} DEV                              |
+    | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
+    | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
+    |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
+    |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
 
 
 ## Reward Distribution {: #reward-distribution } 

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -26,7 +26,6 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     |             Variable             |  |                                                   Value                                                   |
     |:--------------------------------:|::|:---------------------------------------------------------------------------------------------------------:|
     |     Minimum nomination stake     |  |                           {{ networks.moonriver.staking.min_nom_stake }} MOVR                             |
-    |        Minimum nomination        |  |                           {{ networks.moonriver.staking.min_nom_amount}} MOVR                             |
     | Maximum nominators per collators |  |                             {{ networks.moonriver.staking.max_nom_per_col }}                              |
     | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
@@ -37,7 +36,6 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     |             Variable             |  |                                                  Value                                                  |
     |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
     |     Minimum nomination stake     |  |                              {{ networks.moonbase.staking.min_nom_stake }} DEV                          |
-    |        Minimum nomination        |  |                              {{ networks.moonbase.staking.min_nom_amount}} DEV                          |
     | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
     | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
     |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
@@ -52,19 +50,15 @@ There are many extrinsics related to the staking pallet, so all of them are not 
 !!! note
     Extrinsics might change in the future as the staking pallet is updated.
 
- - **nominate**(*address* collator, *uint256* amount) — extrinsic to nominate a collator. The amount must be at least {{ networks.moonbase.staking.min_nom_amount }} tokens
+ - **nominate**(*address* collator, *uint256* amount) — extrinsic to nominate a collator. The amount needs to be greater than the minimum nomination stake
  - **leaveNominators**() — extrinsic to leave the set of nominators. Consequently, all ongoing nominations will be revoked
- - **nominatorBondLess**(*address* collator, *uint256* less) — extrinsic to reduce the amount of staked tokens for an already nominated collator. The amount must not decrease your overall total staked below {{ networks.moonbase.staking.min_nom_stake }} tokens
+ - **nominatorBondLess**(*address* collator, *uint256* less) — extrinsic to reduce the amount of staked tokens for an already nominated collator. The amount must not decrease your overall total staked below the minimum nomination stake
  - **nominatorBondMore**(*address* collator, *uint256* more) — extrinsic to increase the amount of staked tokens for an already nominated collator
  - **revokeNomination**(*address* collator) — extrinsic to remove an existing nomination
 
 ## Retrieving the List of Collators {: #retrieving-the-list-of-collators } 
 
-Before starting to stake tokens, it is important to retrieve the list of collators available in the network. To do so, navigate to "Chain state" under the "Developer" tab.
-
-![Staking Account](/images/staking/staking-stake-1.png)
-
-Here, provide the following information:
+Before starting to stake tokens, it is important to retrieve the list of collators available in the network. To do so:
 
  1. Head to the "Developer" tab 
  2. Click on "Chain State"

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -43,9 +43,7 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
 
---8<-- 'text/moonriver-launch/post-launch.md'
-
-This guide will show you how to stake on Moonbase Alpha.
+This guide will show you how to stake on Moonbase Alpha and Moonriver.
 
 ## Extrinsics Definitions {: #extrinsics-definitions } 
 

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -21,17 +21,6 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
 
 --8<-- 'text/staking/staking-definitions.md'
 
-=== "Moonbase Alpha"
-
-    |             Variable             |  |                                                  Value                                                  |
-    |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                              {{ networks.moonbase.staking.min_nom_stake }} DEV                          |
-    |        Minimum nomination        |  |                              {{ networks.moonbase.staking.min_nom_amount}} DEV                          |
-    | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
-    | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
-    |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
-    |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
-
 === "Moonriver"
 
     |             Variable             |  |                                                   Value                                                   |
@@ -42,6 +31,17 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
+
+=== "Moonbase Alpha"
+
+    |             Variable             |  |                                                  Value                                                  |
+    |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
+    |     Minimum nomination stake     |  |                              {{ networks.moonbase.staking.min_nom_stake }} DEV                          |
+    |        Minimum nomination        |  |                              {{ networks.moonbase.staking.min_nom_amount}} DEV                          |
+    | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
+    | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
+    |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
+    |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
 
 This guide will show you how to stake on Moonbase Alpha and Moonriver.
 

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -41,7 +41,7 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     |              Round               |  | {{ networks.moonbase.staking.round_blocks }} blocks ({{ networks.moonbase.staking.round_hours }} hours) |
     |          Bond duration           |  |                            {{ networks.moonbase.staking.bond_lock }} rounds                             |
 
-This guide will show you how to stake on Moonbase Alpha and Moonriver.
+This guide will show you how to stake on Moonbase Alpha, but the same steps can be followed for Moonriver.
 
 ## Extrinsics Definitions {: #extrinsics-definitions } 
 

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -43,7 +43,7 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
     |              Round               |  | {{ networks.moonriver.staking.round_blocks }} blocks ({{ networks.moonriver.staking.round_hours }} hours) |
     |          Bond duration           |  |                             {{ networks.moonriver.staking.bond_lock }} rounds                             |
 
---8<-- 'text/moonriver-launch/staking-phase-4.md'
+--8<-- 'text/moonriver-launch/post-launch.md'
 
 This guide will show you how to stake on Moonbase Alpha.
 

--- a/staking/stakingprecompile.md
+++ b/staking/stakingprecompile.md
@@ -13,7 +13,7 @@ A delegated proof of stake pallet recently debuted called [Parachain-Staking](ht
 
 The Staking module is coded in Rust and it is part of a pallet that is normally not accessible from the Ethereum side of Moonbeam. However, a Staking Precompile allows developers to access the staking features using the Ethereum API in a precompiled contract located at address `{{networks.moonbase.staking.precompile_address}}`. The Staking Precompile was first released in the [Moonbase Alpha v8 release](https://moonbeam.network/announcements/testnet-upgrade-moonbase-alpha-v8/).
 
-This guide will show you how to interact with the Staking Precompile on Moonbase Alpha and Moonriver.
+This guide will show you how to interact with the Staking Precompile on Moonriver and the Moonbase Alpha TestNet.
 
 ## The Parachain-Staking Solidity Interface {: #the-parachain-staking-solidity-interface } 
 

--- a/staking/stakingprecompile.md
+++ b/staking/stakingprecompile.md
@@ -13,7 +13,7 @@ A delegated proof of stake pallet recently debuted called [Parachain-Staking](ht
 
 The Staking module is coded in Rust and it is part of a pallet that is normally not accessible from the Ethereum side of Moonbeam. However, a Staking Precompile allows developers to access the staking features using the Ethereum API in a precompiled contract located at address `{{networks.moonbase.staking.precompile_address}}`. The Staking Precompile was first released in the [Moonbase Alpha v8 release](https://moonbeam.network/announcements/testnet-upgrade-moonbase-alpha-v8/).
 
-This guide will show you how to interact with the Staking Precompile on Moonriver and the Moonbase Alpha TestNet.
+This guide will show you how to interact with the Staking Precompile on Moonbase Alpha. The same steps can be followed for Moonrvier as well.
 
 ## The Parachain-Staking Solidity Interface {: #the-parachain-staking-solidity-interface } 
 
@@ -73,7 +73,7 @@ The below example is demonstrated on Moonbase Alpha, however, it is compatible w
 
 ## Nominate a Collator {: #nominate-a-collator } 
 
-For this example, we are going to be nominating a collator. Nominators are token holders who stake tokens, vouching for specific collators. Any user that holds a minimum amount of {{networks.moonbase.staking.min_nom_stake}} tokens as free balance can become a nominator. 
+For this example, we are going to be nominating a collator on Moonbase Alpha. Nominators are token holders who stake tokens, vouching for specific collators. Any user that holds a minimum amount of {{networks.moonbase.staking.min_nom_stake}} tokens as free balance can become a nominator. 
 
 In order to nominate a collator, you'll need to determine the current collator nomination count and nominator nomination count. The collator nomination count is the numner of nominations backing a specific collator. The nominator nomination account is the number of nominations made by the nominator.
 

--- a/staking/stakingprecompile.md
+++ b/staking/stakingprecompile.md
@@ -13,7 +13,7 @@ A delegated proof of stake pallet recently debuted called [Parachain-Staking](ht
 
 The Staking module is coded in Rust and it is part of a pallet that is normally not accessible from the Ethereum side of Moonbeam. However, a Staking Precompile allows developers to access the staking features using the Ethereum API in a precompiled contract located at address `{{networks.moonbase.staking.precompile_address}}`. The Staking Precompile was first released in the [Moonbase Alpha v8 release](https://moonbeam.network/announcements/testnet-upgrade-moonbase-alpha-v8/).
 
---8<-- 'text/moonriver-launch/staking-phase-4.md'
+--8<-- 'text/moonriver-launch/post-launch.md'
 
 This guide will show you how to interact with the Staking Precompile on Moonbase Alpha.
 

--- a/staking/stakingprecompile.md
+++ b/staking/stakingprecompile.md
@@ -13,9 +13,7 @@ A delegated proof of stake pallet recently debuted called [Parachain-Staking](ht
 
 The Staking module is coded in Rust and it is part of a pallet that is normally not accessible from the Ethereum side of Moonbeam. However, a Staking Precompile allows developers to access the staking features using the Ethereum API in a precompiled contract located at address `{{networks.moonbase.staking.precompile_address}}`. The Staking Precompile was first released in the [Moonbase Alpha v8 release](https://moonbeam.network/announcements/testnet-upgrade-moonbase-alpha-v8/).
 
---8<-- 'text/moonriver-launch/post-launch.md'
-
-This guide will show you how to interact with the Staking Precompile on Moonbase Alpha.
+This guide will show you how to interact with the Staking Precompile on Moonbase Alpha and Moonriver.
 
 ## The Parachain-Staking Solidity Interface {: #the-parachain-staking-solidity-interface } 
 

--- a/variables.yml
+++ b/variables.yml
@@ -77,6 +77,7 @@ networks:
       min_preim_deposit: 0.004
       max_votes: 100
       max_proposals: 100
+    total_annual_inflation: 5
     staking:
       collator_bond_min: 1000
       collator_map_bond: 100
@@ -85,11 +86,10 @@ networks:
       round_hours: 1
       bond_lock: 2
       min_nom_stake: 5
-      min_nom_amount: 5
       max_nom_per_col: 100
       max_col_per_nom: 25
-      nominator_reward_inflation: 2.5
-      collator_reward_inflation: 1
+      nominator_reward_inflation: 50
+      collator_reward_inflation: 20
       precompile_address: '0x0000000000000000000000000000000000000800'
       collators:
         address1: '0x4c5A56ed5A4FF7B09aA86560AfD7d383F4831Cce'
@@ -102,7 +102,6 @@ networks:
       max_approved_proposals: 100
       tx_fees_allocated: 20
       tx_fees_burned: 80
-      total_annual_inflation: 5
     collator_timings:
       join_leave_candidates:
         rounds: 2
@@ -147,15 +146,7 @@ networks:
       max_votes: 100
       min_preim_deposit: 0.004
       max_proposals: 100
-    treasury:
-      proposal_bond: 5
-      proposal_bond_min: 1
-      spend_period_blocks: 43200
-      spend_period_days: 6
-      max_approved_proposals: 100
-      tx_fees_allocated: 20
-      tx_fees_burned: 80
-      total_annual_inflation: 5
+    total_annual_inflation: 5
     staking:
       collator_bond_min: 1000
       collator_map_bond: 100
@@ -164,11 +155,18 @@ networks:
       round_hours: 1
       bond_lock: 2
       min_nom_stake: 5
-      min_nom_amount: 5
       max_nom_per_col: 100
       max_col_per_nom: 25
-      nominator_reward_inflation: 2.5
-      collator_reward_inflation: 1
+      nominator_reward_inflation: 50
+      collator_reward_inflation: 20
+    treasury:
+      proposal_bond: 5
+      proposal_bond_min: 1
+      spend_period_blocks: 43200
+      spend_period_days: 6
+      max_approved_proposals: 100
+      tx_fees_allocated: 20
+      tx_fees_burned: 80
     collator_timings:
       join_leave_candidates:
         rounds: 2

--- a/variables.yml
+++ b/variables.yml
@@ -161,7 +161,7 @@ networks:
       bond_lock: 2
       min_nom_stake: 5
       min_nom_amount: 5
-      max_nom_per_col: 10
+      max_nom_per_col: 100
       max_col_per_nom: 25
     collator_timings:
       join_leave_candidates:

--- a/variables.yml
+++ b/variables.yml
@@ -89,6 +89,8 @@ networks:
       max_nom_per_col: 10
       max_col_per_nom: 25
       precompile_address: '0x0000000000000000000000000000000000000800'
+      nominator_reward_as_percent_of_inflation: 50
+      collator_reward_as_percent_of_inflation: 50
       collators:
         address1: '0x4c5A56ed5A4FF7B09aA86560AfD7d383F4831Cce'
         address2: '0x623c9E50647a049F92090fe55e22cC0509872FB6'
@@ -100,6 +102,7 @@ networks:
       max_approved_proposals: 100
       tx_fees_allocated: 20
       tx_fees_burned: 80
+      total_annual_inflation: 5
     collator_timings:
       join_leave_candidates:
         rounds: 2
@@ -152,6 +155,7 @@ networks:
       max_approved_proposals: 100
       tx_fees_allocated: 20
       tx_fees_burned: 80
+      total_annual_inflation: 5
     staking:
       collator_bond_min: 1000
       collator_map_bond: 100
@@ -163,6 +167,8 @@ networks:
       min_nom_amount: 5
       max_nom_per_col: 100
       max_col_per_nom: 25
+      nominator_reward_as_percent_of_inflation: 50
+      collator_reward_as_percent_of_inflation: 50
     collator_timings:
       join_leave_candidates:
         rounds: 2

--- a/variables.yml
+++ b/variables.yml
@@ -86,11 +86,11 @@ networks:
       bond_lock: 2
       min_nom_stake: 5
       min_nom_amount: 5
-      max_nom_per_col: 10
+      max_nom_per_col: 100
       max_col_per_nom: 25
+      nominator_reward_inflation: 2.5
+      collator_reward_inflation: 1
       precompile_address: '0x0000000000000000000000000000000000000800'
-      nominator_reward_as_percent_of_inflation: 50
-      collator_reward_as_percent_of_inflation: 50
       collators:
         address1: '0x4c5A56ed5A4FF7B09aA86560AfD7d383F4831Cce'
         address2: '0x623c9E50647a049F92090fe55e22cC0509872FB6'
@@ -167,8 +167,8 @@ networks:
       min_nom_amount: 5
       max_nom_per_col: 100
       max_col_per_nom: 25
-      nominator_reward_as_percent_of_inflation: 50
-      collator_reward_as_percent_of_inflation: 50
+      nominator_reward_inflation: 2.5
+      collator_reward_inflation: 1
     collator_timings:
       join_leave_candidates:
         rounds: 2


### PR DESCRIPTION
Initial commit. Adds the quick reference section to the Staking/Overview page that can be linked to provide a quick reference on the most commonly asked staking related questions. 

Also updates the max_nom_per_col global variable for Moonriver to match today's update. 