### PR TITLE
remove duplicate min nomination variables

### DIFF
--- a/networks/moonriver.md
+++ b/networks/moonriver.md
@@ -49,7 +49,6 @@ Some important variables/configurations to note include:
 === "Staking"
     |             Variable             |                                                     Value                                                     |
     |:--------------------------------:|:-------------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |                           {{ networks.moonriver.staking.    min_nom_stake }} tokens                           |
     |        Minimum nomination        |                           {{ networks.moonriver.staking.    min_nom_amount}} tokens                           |
     | Maximum nominators per collators |                             {{ networks.moonriver.staking.    max_nom_per_col }}                              |
     | Maximum collators per nominator  |                             {{ networks.moonriver.staking.    max_col_per_nom }}                              |

--- a/staking/overview.md
+++ b/staking/overview.md
@@ -23,7 +23,6 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 
     |             Variable             |  |                                                  Value                                                  |
     |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                          {{ networks.moonbase.staking.min_nom_stake }} DEV                              |
     |        Minimum nomination        |  |                          {{ networks.moonbase.staking.min_nom_amount}} DEV                              |
     | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
     | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
@@ -34,7 +33,6 @@ Collators (and token holders if they nominate) have a stake in the network. The 
 
     |             Variable             |  |                                                   Value                                                   |
     |:--------------------------------:|::|:---------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                           {{ networks.moonriver.staking.min_nom_stake }} MOVR                             |
     |        Minimum nomination        |  |                           {{ networks.moonriver.staking.min_nom_amount}} MOVR                             |
     | Maximum nominators per collators |  |                             {{ networks.moonriver.staking.max_nom_per_col }}                              |
     | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |

--- a/staking/stake.md
+++ b/staking/stake.md
@@ -25,7 +25,6 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
 
     |             Variable             |  |                                                  Value                                                  |
     |:--------------------------------:|::|:-------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                              {{ networks.moonbase.staking.min_nom_stake }} DEV                          |
     |        Minimum nomination        |  |                              {{ networks.moonbase.staking.min_nom_amount}} DEV                          |
     | Maximum nominators per collators |  |                             {{ networks.moonbase.staking.max_nom_per_col }}                             |
     | Maximum collators per nominator  |  |                             {{ networks.moonbase.staking.max_col_per_nom }}                             |
@@ -36,7 +35,6 @@ With the release of [Moonbase Alpha v6](https://github.com/PureStake/moonbeam/re
 
     |             Variable             |  |                                                   Value                                                   |
     |:--------------------------------:|::|:---------------------------------------------------------------------------------------------------------:|
-    |     Minimum nomination stake     |  |                           {{ networks.moonriver.staking.min_nom_stake }} MOVR                             |
     |        Minimum nomination        |  |                           {{ networks.moonriver.staking.min_nom_amount}} MOVR                             |
     | Maximum nominators per collators |  |                             {{ networks.moonriver.staking.max_nom_per_col }}                              |
     | Maximum collators per nominator  |  |                             {{ networks.moonriver.staking.max_col_per_nom }}                              |
@@ -56,7 +54,7 @@ There are many extrinsics related to the staking pallet, so all of them are not 
 
  - **nominate**(*address* collator, *uint256* amount) — extrinsic to nominate a collator. The amount must be at least {{ networks.moonbase.staking.min_nom_amount }} tokens
  - **leaveNominators**() — extrinsic to leave the set of nominators. Consequently, all ongoing nominations will be revoked
- - **nominatorBondLess**(*address* collator, *uint256* less) — extrinsic to reduce the amount of staked tokens for an already nominated collator. The amount must not decrease your overall total staked below {{ networks.moonbase.staking.min_nom_stake }} tokens
+ - **nominatorBondLess**(*address* collator, *uint256* less) — extrinsic to reduce the amount of staked tokens for an already nominated collator. The amount must not decrease your overall total staked below {{ networks.moonbase.staking.min_nom_amount }} tokens
  - **nominatorBondMore**(*address* collator, *uint256* more) — extrinsic to increase the amount of staked tokens for an already nominated collator
  - **revokeNomination**(*address* collator) — extrinsic to remove an existing nomination
 

--- a/staking/stakingprecompile.md
+++ b/staking/stakingprecompile.md
@@ -45,10 +45,10 @@ The interface includes the following functions:
 The below example is demonstrated on Moonbase Alpha, however, it is compatible with all networks including Moonriver and Moonbeam.
 
  - Have MetaMask installed and [connected to Moonbase Alpha](/getting-started/moonbase/metamask/)
- - Have an account with over `{{networks.moonbase.staking.min_nom_stake}}` tokens. You can get this from [Mission Control](/getting-started/moonbase/faucet/)
+ - Have an account with over `{{networks.moonbase.staking.min_nom_amount}}` tokens. You can get this from [Mission Control](/getting-started/moonbase/faucet/)
 
 !!! note
-    The example below requires more than `{{networks.moonbase.staking.min_nom_stake}}` tokens due to the minimum nomination amount plus gas fees. If you need more than the faucet dispenses, please contact us on Discord and we will be happy to help you. 
+    The example below requires more than `{{networks.moonbase.staking.min_nom_amount}}` tokens due to the minimum nomination amount plus gas fees. If you need more than the faucet dispenses, please contact us on Discord and we will be happy to help you. 
 
 ## Remix Set Up {: #remix-set-up } 
 
@@ -75,7 +75,7 @@ The below example is demonstrated on Moonbase Alpha, however, it is compatible w
 
 ## Nominate a Collator {: #nominate-a-collator } 
 
-For this example, we are going to be nominating a collator. Nominators are token holders who stake tokens, vouching for specific collators. Any user that holds a minimum amount of {{networks.moonbase.staking.min_nom_stake}} tokens as free balance can become a nominator. 
+For this example, we are going to be nominating a collator. Nominators are token holders who stake tokens, vouching for specific collators. Any user that holds a minimum amount of {{networks.moonbase.staking.min_nom_amount}} tokens as free balance can become a nominator. 
 
 In order to nominate a collator, you'll need to determine the current collator nomination count and nominator nomination count. The collator nomination count is the numner of nominations backing a specific collator. The nominator nomination account is the number of nominations made by the nominator.
 
@@ -91,7 +91,7 @@ In order to nominate a collator, you'll need to determine the current collator n
 
 1. Expand the panel with the contract address. Locate the nominate function and expand the panel to see the parameters
 2. Provide the address of a collator such as `{{ networks.moonbase.staking.collators.address1 }}`
-3. Provide the amount to nominate in WEI. There is a minimum of `{{networks.moonbase.staking.min_nom_stake}}` tokens to nominate, so the lowest amount in WEI is `5000000000000000000`
+3. Provide the amount to nominate in WEI. There is a minimum of `{{networks.moonbase.staking.min_nom_amount}}` tokens to nominate, so the lowest amount in WEI is `5000000000000000000`
 4. Provide the nomination count for the collator provided in Step 2
 5. Provide your nomination count
 6. Press "transact" and confirm the transaction in Metamask

--- a/variables.yml
+++ b/variables.yml
@@ -84,7 +84,6 @@ networks:
       round_blocks: 300
       round_hours: 1
       bond_lock: 2
-      min_nom_stake: 5
       min_nom_amount: 5
       max_nom_per_col: 10
       max_col_per_nom: 25
@@ -159,7 +158,6 @@ networks:
       round_blocks: 300
       round_hours: 1
       bond_lock: 2
-      min_nom_stake: 5
       min_nom_amount: 5
       max_nom_per_col: 10
       max_col_per_nom: 25


### PR DESCRIPTION
we had duplicate variables for min nomination, `min_nom_stake` and `min_nom_amount`, so just reduced that to `min_nom_amount` 