### PR TITLE
update network names in metamask configs

### DIFF
--- a/js/connectMetaMask.js
+++ b/js/connectMetaMask.js
@@ -9,7 +9,7 @@ const connectMetaMaskNav = document.querySelector('.connectMetaMask-nav');
 const supportedNetworks = {
   moonbase: {
     chainId: moonbaseAlphaChainId,
-    chainName: 'Moonbase Alpha',
+    chainName: 'Moonbeam TestNet Moonbase Alpha',
     rpcUrls: ['https://rpc.testnet.moonbeam.network'],
     blockExplorerUrls: [
       'https://moonbase-blockscout.testnet.moonbeam.network/',
@@ -22,7 +22,7 @@ const supportedNetworks = {
   },
   moonriver: {
     chainId: moonriverChainId,
-    chainName: 'Moonriver',
+    chainName: 'Moonriver Kusama',
     rpcUrls: ['https://rpc.moonriver.moonbeam.network'],
     blockExplorerUrls: ['https://blockscout.moonriver.moonbeam.network/'],
     nativeCurrency: {


### PR DESCRIPTION
update the network names for Moonriver and Moonbase Alpha in the connect metamask config to be Moonriver Kusama and Moonbeam TestNet Moonbase Alpha to match the entries here:

Moonbase Alpha: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1287.json
Moonriver: https://github.com/ethereum-lists/chains/blob/master/_data/chains/eip155-1285.json

This ultimately gets rid of the chain doesn't match error when initially trying to connect metamask to moonbase or moonriver