### PR TITLE
use iso format to display languages in select if user is on mobile

### DIFF
--- a/js/handleLanguageChange.js
+++ b/js/handleLanguageChange.js
@@ -48,7 +48,7 @@ const displayLanguage = (label, language, abbreviatedLanguage) => {
         a.substr(0, 4)
       )
     )
-      check = true;
+      isMobile = true;
   })(navigator.userAgent || navigator.vendor || window.opera);
 
   if (isMobile) {


### PR DESCRIPTION
set the `isMobile` flag if user happens to be on a mobile device so the language select displays the iso formatted abbreviation of each language... 
<img width="436" alt="Screen Shot 2021-09-03 at 2 55 46 PM" src="https://user-images.githubusercontent.com/26533957/132065001-0e18b7f0-cafa-48c4-8f15-ba1c45762612.png">
