### PR TITLE
Fix command to get latest tag when compiling binary

### DIFF
--- a/node-operators/networks/compile-binary.md
+++ b/node-operators/networks/compile-binary.md
@@ -27,7 +27,7 @@ cd moonbeam
 Let's check out the latest release:
 
 ```
-git checkout tags/$(git tag | tail -1)
+git checkout tags/$(git describe --tags)
 ```
 
 If you already have Rust installed, you can skip the next two steps. Otherwise, install Rust and its prerequisites [via Rust's recommended method](https://www.rust-lang.org/tools/install){target=_blank} by executing:


### PR DESCRIPTION
`git checkout tags/$(git tag | tail -1)` gets the last tag in alphabetical order.
Since 0.9.0 > 0.10.0 in alphabetical order, this isn't giving the latest version.
Correct command: `git checkout tags/$(git describe --tags)`