### PR TITLE
update max Collators for MB Alpha and update release version tag

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -127,7 +127,7 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.13.0
+    parachain_release_tag: v0.14.2
     parachain_sha256sum: 0223dfeeec38a70f4fd5f4666944dfc5d3b6520c60f000a458f42121682fcfaf
     chain_spec: moonriver
     block_explorer: https://blockscout.moonriver.moonbeam.network/

--- a/variables.yml
+++ b/variables.yml
@@ -1,6 +1,6 @@
 networks:
   development:
-    build_tag: v0.13.2
+    build_tag: v0.14.2
     rpc_url: http://127.0.0.1:9933
     chain_id: 1281
     hex_chain_id: '0x501'
@@ -12,7 +12,7 @@ networks:
     hex_chain_id: '0x507'
     chain_spec: alphanet
     block_explorer: https://moonbase-blockscout.testnet.moonbeam.network/
-    parachain_release_tag: v0.13.2 # must be in this exact format for links to work
+    parachain_release_tag: v0.14.2 # must be in this exact format for links to work
     parachain_sha256sum: 9e748a0c91d5ed5f999bae91ceed1343db0d9dda40270201abf00db067c86a71
     gas_block: 15M
     gas_tx: 12.995M
@@ -86,7 +86,7 @@ networks:
     staking:
       collator_bond_min: 1000
       collator_map_bond: 100
-      max_collators: 40
+      max_collators: 60
       round_blocks: 300
       round_hours: 1
       bond_lock: 2

--- a/variables.yml
+++ b/variables.yml
@@ -13,7 +13,7 @@ networks:
     chain_spec: alphanet
     block_explorer: https://moonbase-blockscout.testnet.moonbeam.network/
     parachain_release_tag: v0.14.2 # must be in this exact format for links to work
-    parachain_sha256sum: 9e748a0c91d5ed5f999bae91ceed1343db0d9dda40270201abf00db067c86a71
+    parachain_sha256sum: 0223dfeeec38a70f4fd5f4666944dfc5d3b6520c60f000a458f42121682fcfaf
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data
@@ -128,7 +128,7 @@ networks:
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
     parachain_release_tag: v0.13.0
-    parachain_sha256sum: 9e748a0c91d5ed5f999bae91ceed1343db0d9dda40270201abf00db067c86a71
+    parachain_sha256sum: 0223dfeeec38a70f4fd5f4666944dfc5d3b6520c60f000a458f42121682fcfaf
     chain_spec: moonriver
     block_explorer: https://blockscout.moonriver.moonbeam.network/
     binary_name: moonbeam


### PR DESCRIPTION
- Update max Collators for Moonbase Alpha to 60.
- Update version release tag to 0.14.2