### PR TITLE
update erc-* and dapps for consistency

### DIFF
--- a/builders/get-started/eth-compare/rpc-support.md
+++ b/builders/get-started/eth-compare/rpc-support.md
@@ -9,7 +9,7 @@ description: A description of the main differences that Ethereum developers need
 
 While Moonbeam strives to be compatible with Ethereum's Web3 API and EVM, there are some important Moonbeam differences that developers should know and understand in terms of the [Ethereum API JSON-RPC](https://eth.wiki/json-rpc/API#json-rpc-methods) support.
 
-The Moonbeam team has collaborated closely with [Parity](https://www.parity.io/) on developing [Frontier](https://github.com/paritytech/frontier). Frontier is the Ethereum compatibility layer for Substrate based chains, and it is what allows developers to run unmodified Ethereum dApps.
+The Moonbeam team has collaborated closely with [Parity](https://www.parity.io/) on developing [Frontier](https://github.com/paritytech/frontier). Frontier is the Ethereum compatibility layer for Substrate based chains, and it is what allows developers to run unmodified Ethereum DApps.
 
 Nevertheless, not all of the Ethereum JSON RPC methods are supported, and some of the supported ones return default values (those related to PoW). This guide will outline some of these main differences around Ethereum RPC support and what to expect when using Moonbeam for the first time.
 

--- a/builders/integrations/bridges/eth/chainbridge.md
+++ b/builders/integrations/bridges/eth/chainbridge.md
@@ -103,7 +103,7 @@ In simple terms, the modified contract used to initiate the transfer has the _ch
 
 The general workflow for this example can be seen in this diagram:
 
-![ChainBridge ERC20 workflow](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-erc20.png)
+![ChainBridge ERC-20 workflow](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-erc20.png)
 
 To try the bridge with this sample ERC-20 token, we must do the following steps (regardless of the direction of the transfer):
  
@@ -122,7 +122,7 @@ Let's send some ERC20S tokens from **Moonbase Alpha** to **Kovan**. If you wante
 pragma solidity ^0.8.1;
 
 /**
-    Interface for the Custom ERC20 Token contract for ChainBridge implementation
+    Interface for the Custom ERC-20 Token contract for ChainBridge implementation
     Kovan/Rinkeby - Moonbase Alpha ERC-20 Address : 
         {{ networks.moonbase.chainbridge.ERC20S }}
 */
@@ -149,7 +149,7 @@ interface ICustomERC20 {
 
 Note that the ERC-20 token contract's mint function was also modified to approve the corresponding handler contract as a spender when minting tokens.
 
-After adding the Custom ERC20 contract to Remix and compiling it, the next steps are to mint ERC20S tokens:
+After adding the Custom ERC-20 contract to Remix and compiling it, the next steps are to mint ERC20S tokens:
 
 1. Navigate to the **Deploy & Run Transactions** page on Remix
 2. Select Injected Web3 from the **Environment** dropdown
@@ -157,7 +157,7 @@ After adding the Custom ERC20 contract to Remix and compiling it, the next steps
 4. Call the `mintTokens()` function and sign the transaction. 
 5. Once the transaction is confirmed, you should have received 5 ERC20S tokens. You can check your balance by adding the token to [MetaMask](/tokens/connect/metamask/).
 
-![ChainBridge ERC20 mint Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-1.png)
+![ChainBridge ERC-20 mint Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-1.png)
 
 Once we have the tokens, we can proceed to send them over the bridge to the target chain. In this case, remember that we do it from **Moonbase Alpha** to **Kovan**. There is a single interface that will allow you to transfer ERC20S and ERC721M tokens. For this example you will use the `sendERC20SToken()` function to initiate the transfer of your minted ERC20S tokens:
 
@@ -173,7 +173,7 @@ pragma solidity 0.8.1;
 interface IBridge {
 
     /**
-     * Calls the `deposit` function of the Chainbridge Bridge contract for the custom ERC20 (ERC20Sample) 
+     * Calls the `deposit` function of the Chainbridge Bridge contract for the custom ERC-20 (ERC20Sample) 
      * by building the requested bytes object from: the recipient, the specified amount and the destination
      * chainId.
      * @notice Use the destination `eth_chainId`.
@@ -190,7 +190,7 @@ interface IBridge {
 }
 ```
 
-After adding the Bridge contract to Remix and compiling it, in order to send ERC20s tokens over the bridge you'll need to:
+After adding the Bridge contract to Remix and compiling it, in order to send ERC20S tokens over the bridge you'll need to:
 
 1. Load the bridge contract address and click **At Address**
 2. To call the `sendERC20SToken()` function, enter the destination chain ID (For this example we are using Kovan: `42`)
@@ -200,22 +200,22 @@ After adding the Bridge contract to Remix and compiling it, in order to send ERC
 
 Once the transaction is confirmed, the process can take around 3 minutes to complete, after which you should have received the tokens in Kovan!
 
-![ChainBridge ERC20 send Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-2.png)
+![ChainBridge ERC-20 send Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-2.png)
 
 You can check your balance by adding the token to [MetaMask](/tokens/connect/metamask/) and connecting it to the target network - in our case Kovan.
 
-![ChainBridge ERC20 balance](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-3.png)
+![ChainBridge ERC-20 balance](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-3.png)
 
-Remember that you can also mint ERC20S tokens in Kovan and send them to Moonbase Alpha. To approve a spender or increase its allowance, you can use the `increaseAllowance()` function of the interface provided. To check the allowance of the handler contract in the ERC20 token contract, you can use the `allowance()` function of the interface.
+Remember that you can also mint ERC20S tokens in Kovan and send them to Moonbase Alpha. To approve a spender or increase its allowance, you can use the `increaseAllowance()` function of the interface provided. To check the allowance of the handler contract in the ERC-20 token contract, you can use the `allowance()` function of the interface.
 
 !!! note
     Tokens will be transferred only if the handler contract has enough allowance to spend tokens on behalf of the owner. If the process fails, check the allowance.
 
 ### ERC-721 Token Transfer {: #erc-721-token-transfer } 
 
-Similar to our previous example, ERC-721 tokens contracts need to be registered by the relayers to enable transfer through the bridge. Therefore, we've customized an ERC-721 token contract so that any user can mint a token to test the bridge out. However, as each token is non-fungible, and consequently unique, the mint function is only available in the Source chain token contract and not in the Target contract. In other words, ERC-721M tokens can only be minted on Moonbase Alpha and then transfered to Rinkeby or Kovan. The following diagram explains the workflow for this example, where it is important to highlight that the token ID and metadata is maintained.
+Similar to our previous example, ERC-721 tokens contracts need to be registered by the relayers to enable transfer through the bridge. Therefore, we've customized an ERC-721 token contract so that any user can mint a token to test the bridge out. However, as each token is non-fungible, and consequently unique, the mint function is only available in the Source chain token contract and not in the Target contract. In other words, ERC721M tokens can only be minted on Moonbase Alpha and then transfered to Rinkeby or Kovan. The following diagram explains the workflow for this example, where it is important to highlight that the token ID and metadata is maintained.
 
-![ChainBridge ERC721 workflow](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-erc721.png)
+![ChainBridge ERC-721 workflow](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-erc721.png)
 
 To mint tokens in Moonbase Alpha (named ERC721Moon with symbol ERC721M) and send them back-and-forth to Kovan/Rinkeby, you need the following address:
 
@@ -240,7 +240,7 @@ Let's send an ERC721M token from **Moonbase Alpha** to **Kovan**. For that, we'l
 pragma solidity ^0.8.1;
 
 /**
-    Interface for the Custom ERC721 Token contract for ChainBridge implementation:
+    Interface for the Custom ERC-721 Token contract for ChainBridge implementation:
     Kovan/Rinkeby - Moonbase Alpha:
         ERC721Moon: {{ networks.moonbase.chainbridge.ERC721M }}
 
@@ -283,7 +283,7 @@ After adding the contract to Remix and compiling it, next we'll want to mint an 
 4. Call the `mintTokens()` function and sign the transaction. 
 5. Once the transaction is confirmed, you should have received an ERC721M token. You can check your balance by adding the token to [MetaMask](/tokens/connect/metamask/).
 
-![ChainBridge ERC721 mint Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-4.png) 
+![ChainBridge ERC-721 mint Tokens](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-4.png) 
 
 The following interface allows you to use the `sendERC721MoonToken()` function to initiate the transfer of tokens originally minted in Moonbase Alpha (ERC721M).
 
@@ -299,7 +299,7 @@ pragma solidity 0.8.1;
 interface IBridge {
 
     /**
-     * Calls the `deposit` function of the Chainbridge Bridge contract for the custom ERC20 (ERC20Sample) 
+     * Calls the `deposit` function of the Chainbridge Bridge contract for the custom ERC-20 (ERC20Sample) 
      * by building the requested bytes object from: the recipient, the specified amount and the destination
      * chainId.
      * @notice Use the destination `eth_chainId`.
@@ -307,7 +307,7 @@ interface IBridge {
     function sendERC20SToken(uint256 destinationChainID, address recipient, uint256 amount) external;
     
     /**
-     * Calls the `deposit` function for the custom ERC721 (ERC721Moon) that is only mintable in the
+     * Calls the `deposit` function for the custom ERC-721 (ERC721Moon) that is only mintable in the
      * MOON side of the bridge. It builds the bytes object requested by the method from: the recipient,
      * the specified token ID and the destination chainId.
      * @notice Use the destination `eth_chainId`.
@@ -326,13 +326,13 @@ Now you can proceed to send the ERC721M token over the bridge to the target chai
 
 Once the transaction is confirmed, the process can take around 3 minute to complete, after which you should have received the same token ID in Kovan!
 
-![ChainBridge ERC721 send Token](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-5.png)
+![ChainBridge ERC-721 send Token](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-5.png)
 
 You can check your balance by adding the token to [MetaMask](/tokens/connect/metamask/) and connecting it to the target network, in our case Kovan.
 
-![ChainBridge ERC721 balance](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-6.png)
+![ChainBridge ERC-721 balance](/images/builders/integrations/bridges/eth/chainbridge/chainbridge-6.png)
 
-Remember that ERC721M tokens are only mintable in Moonbase Alpha and then they will be available to send back and forth to Kovan or Rinkeby. It is important to always check the allowance provided to the handler contract in the corresponding ERC721 token contract. You can approve the handler contract to send tokens on your behalf using the `approve()` function provided in the interface. You can check the approval of each of your token IDs with the `getApproved()` function.
+Remember that ERC721M tokens are only mintable in Moonbase Alpha and then they will be available to send back and forth to Kovan or Rinkeby. It is important to always check the allowance provided to the handler contract in the corresponding ERC-721 token contract. You can approve the handler contract to send tokens on your behalf using the `approve()` function provided in the interface. You can check the approval of each of your token IDs with the `getApproved()` function.
 
 !!! note
     Tokens will be transferred only if the handler contract is approved to transfer tokens on behalf of the owner. If the process fails, check the approval.

--- a/builders/integrations/indexers/covalent.md
+++ b/builders/integrations/indexers/covalent.md
@@ -36,10 +36,10 @@ The Covalent API has two classes of endpoints:
  - The refresh rate of the APIs is real-time: 30s or 2 blocks, and batch 10m or 40 blocks  
 
 ## Supported Endpoints {: #supported-endpoints } 
- - **Balances** — Get token balances for an address. Returns a list of all ERC20 and NFT token balances including ERC721 and ERC1155 along with their current spot prices (if available)
+ - **Balances** — Get token balances for an address. Returns a list of all ERC-20 and NFT token balances including ERC-721 and ERC-1155 along with their current spot prices (if available)
  - **Transactions** — Retrieves all transactions for an address including decoded log events. Does a deep-crawl of the blockchain to 
  retrieve all transactions that reference this address
- - **Transfers** — Get ERC20 token transfers for an address along with historical token prices (if available)
+ - **Transfers** — Get ERC-20 token transfers for an address along with historical token prices (if available)
  - **Token Holders** — Return a paginated list of token holders
  - **Log Events (Smart Contract)** — Return a paginated list of decoded log events emitted by a particular smart contract
  - **Log Events (Topic Hash)** — Return a paginated list of decoded log events with one or more topic hashes separated by a comma
@@ -130,7 +130,7 @@ Copy and paste the below code block into your preferred environment, or [JSFiddl
 
     ```
 
-The output should resemble the below. The balances endpoint returns a list of all ERC20 and NFT token balances including ERC721 and ERC1155 along with their current spot prices (if available).
+The output should resemble the below. The balances endpoint returns a list of all ERC-20 and NFT token balances including ERC-721 and ERC-1155 along with their current spot prices (if available).
 
 ![Javascript Console Output](/images/builders/integrations/indexers/covalent/covalentjs.png)
 

--- a/builders/integrations/indexers/thegraph.md
+++ b/builders/integrations/indexers/thegraph.md
@@ -11,7 +11,7 @@ description: Build APIs using The Graph indexing protocol on Moonbeam
 
 Indexing protocols organize information in a way that applications can access it more efficiently. For example, Google indexes the entire internet to provide information rapidly when you search for something.
 
-The Graph is a decentralized and open-source indexing protocol for querying networks like Ethereum. In short, it provides a way to efficiently store data emitted by events from smart contracts so that other projects or dApps can access it easily.
+The Graph is a decentralized and open-source indexing protocol for querying networks like Ethereum. In short, it provides a way to efficiently store data emitted by events from smart contracts so that other projects or DApps can access it easily.
 
 Furthermore, developers can build APIs, called Subgraphs. Users or other developers can use Subgraphs to query data specific to a set of smart contracts. Data is fetched with a standard GraphQL API. You can visit [their documentation](https://thegraph.com/docs/about/introduction#what-the-graph-is) to read more about The Graph protocol.
 
@@ -102,7 +102,7 @@ There is no particular order to follow when modifying the files to create a Subg
 
 ### Schema.graphql {: #schemagraphql } 
 
-It is important to outline what data needs to be extracted from the events of the contract before modifying the `schema.graphql`. Schemas need to be defined considering the requirements of the dApp itself. For this example, although there is no dApp associated with the lottery, four entities are defined:
+It is important to outline what data needs to be extracted from the events of the contract before modifying the `schema.graphql`. Schemas need to be defined considering the requirements of the DApp itself. For this example, although there is no DApp associated with the lottery, four entities are defined:
 
  - **Round** — refers to a lottery round. It stores an index of the round, the prize awarded, the timestamp of when the round started, the timestamp of when the winner was drawn, and information regarding the participating tickets, which is derived from the `Ticket` entity
  - **Player** — refers to a player that has participated in at least one round. It stores its address and information from all its participating tickets, which is derived from the `Ticket` entity

--- a/builders/interact/oz-remix.md
+++ b/builders/interact/oz-remix.md
@@ -24,18 +24,18 @@ OpenZeppelin has developed an online web-based interactive contract generator to
 
 Currently, the Contracts Wizard support the following ERC standards:
 
- - [**ERC20**](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) — a fungible token standard that follows [EIP-20](https://eips.ethereum.org/EIPS/eip-20). Fungible means that all tokens are equivalent and interchangeable that is, of equal value. One typical example of fungible tokens is fiat currencies, where each equal-denomination bill has the same value.
- - [**ERC721**](https://ethereum.org/en/developers/docs/standards/tokens/erc-721/) — a non-fungible token contract that follows [EIP-721](https://eips.ethereum.org/EIPS/eip-721). Non-fungible means that each token is different, and therefore, unique. An ERC721 token can represent ownership of that unique item, whether it is a collectible item in a game, real estate, and so on. 
- - [**ERC1155**](https://docs.openzeppelin.com/contracts/4.x/erc1155) — also known as the multi-token contract, because it can represent both fungible and non-fungible tokens in a single smart contract. It follows [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155)
+ - [**ERC-20**](https://ethereum.org/en/developers/docs/standards/tokens/erc-20/) — a fungible token standard that follows [EIP-20](https://eips.ethereum.org/EIPS/eip-20). Fungible means that all tokens are equivalent and interchangeable that is, of equal value. One typical example of fungible tokens is fiat currencies, where each equal-denomination bill has the same value.
+ - [**ERC-721**](https://ethereum.org/en/developers/docs/standards/tokens/erc-721/) — a non-fungible token contract that follows [EIP-721](https://eips.ethereum.org/EIPS/eip-721). Non-fungible means that each token is different, and therefore, unique. An ERC-721 token can represent ownership of that unique item, whether it is a collectible item in a game, real estate, and so on. 
+ - [**ERC-1155**](https://docs.openzeppelin.com/contracts/4.x/erc1155) — also known as the multi-token contract, because it can represent both fungible and non-fungible tokens in a single smart contract. It follows [EIP-1155](https://eips.ethereum.org/EIPS/eip-1155)
 
 The wizard is comprised of the following sections:
 
  1. **Token standard selection** — shows all the different standards supported by the wizard
  2. **Settings** — provides the baseline settings for each token standard, such as token name, symbol, pre-mint (token supply when the contract is deployed), and URI (for non-fungible tokens)
  3. **Features** — list of all features available for each token standard. You can find more information about the different features in the following links:
-     - [ERC20](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20)
-     - [ERC721](https://docs.openzeppelin.com/contracts/4.x/api/token/erc721)
-     - [ERC1155](https://docs.openzeppelin.com/contracts/4.x/api/token/erc1155)
+     - [ERC-20](https://docs.openzeppelin.com/contracts/4.x/api/token/erc20)
+     - [ERC-721](https://docs.openzeppelin.com/contracts/4.x/api/token/erc721)
+     - [ERC-1155](https://docs.openzeppelin.com/contracts/4.x/api/token/erc1155)
  4. **Access Control** — list of all the available [access control mechanisms](https://docs.openzeppelin.com/contracts/4.x/access-control) for each token standard
  5. **Interactive code display** — shows the smart contract code with the configuration as set by the user
 
@@ -47,9 +47,9 @@ Once you have set up your contract with all the settings and features, it is jus
 
 This section goes through the steps for deploying OpenZeppelin contracts on Moonbeam. It covers the following contracts:
 
- - ERC20 (fungible tokens)
- - ERC721 (non-fungible tokens)
- - ERC1155 (multi-token standard)
+ - ERC-20 (fungible tokens)
+ - ERC-721 (non-fungible tokens)
+ - ERC-1155 (multi-token standard)
 
 All the code of the contracts was obtained using OpenZeppelin [Contract Wizard](https://docs.openzeppelin.com/contracts/4.x/wizard).
  
@@ -60,14 +60,14 @@ The steps described in this section assume you have [MetaMask](https://metamask.
  - [Interacting with Moonbeam using MetaMask](/tokens/connect/metamask/)
  - [Interacting with Moonbeam using Remix](/builders/tools/remix/)
 
-### Deploying an ERC20 Token {: #deploying-an-erc20-token } 
+### Deploying an ERC-20 Token {: #deploying-an-erc-20-token } 
 
-For this example, an ERC20 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
+For this example, an ERC-20 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
 
- - **ERC20.sol** — ERC20 token implementation with the optional features from the base interface. Includes the supply mechanism with a `mint` function but needs to be explicitly called from within the main contract
+ - **ERC20.sol** — ERC-20 token implementation with the optional features from the base interface. Includes the supply mechanism with a `mint` function but needs to be explicitly called from within the main contract
  - **Ownable.sol** — extension to restrict access to certain functions
 
-The mintable ERC20 OpenZeppelin token contract provides a `mint` function that the owner of the contract can only call. By default, the owner is the contract's deployer address. There is also a premint of `1000` tokens sent to the contract's deployer configured in the `constructor` function.
+The mintable ERC-20 OpenZeppelin token contract provides a `mint` function that the owner of the contract can only call. By default, the owner is the contract's deployer address. There is also a premint of `1000` tokens sent to the contract's deployer configured in the `constructor` function.
 
 The first step is to go to [Remix](https://remix.ethereum.org/) and take the following steps:
 
@@ -92,7 +92,7 @@ contract MyToken is ERC20, Ownable {
 }
 ```
 
-This ERC20 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting a premint of `1000` tokens and activating the `Mintable` feature.
+This ERC-20 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting a premint of `1000` tokens and activating the `Mintable` feature.
 
 ![Getting Started with Remix](/images/builders/interact/oz-remix/oz-contracts-1.png)
 
@@ -102,7 +102,7 @@ Once your smart contract is written, you can compile it by taking the following 
  2. Click on the compile button
  3. Alternatively, you can check the "Auto compile" feature
 
-![Compile ERC20 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-2.png)
+![Compile ERC-20 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-2.png)
 
 With the contract compiled, you are ready to deploy it taking the following steps: 
 
@@ -112,22 +112,22 @@ With the contract compiled, you are ready to deploy it taking the following step
  4. If everything is ready, click on the "Deploy" button. Review the transaction information in MetaMask and confirm it
  5. After a few seconds, the transaction should get confirmed, and you should see your contract under "Deployed Contracts"
 
-![Deploy ERC20 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-3.png)
+![Deploy ERC-20 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-3.png)
 
-And that is it! You've deployed an ERC20 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix, or add it to MetaMask.
+And that is it! You've deployed an ERC-20 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix, or add it to MetaMask.
 
-### Deploying an ERC721 Token {: #deploying-an-erc721-token } 
+### Deploying an ERC-721 Token {: #deploying-an-erc-721-token } 
 
-For this example, an ERC721 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
+For this example, an ERC-721 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
 
- - **ERC721** — ERC721 token implementation with the optional features from the base interface. Includes the supply mechanism with a `_mint` function but needs to be explicitly called from within the main contract
+ - **ERC-721** — ERC-721 token implementation with the optional features from the base interface. Includes the supply mechanism with a `_mint` function but needs to be explicitly called from within the main contract
  - **Burnable** — extension to allow tokens to be destroyed by their owners (or approved addresses)
  - **Enumerable** — extension to allow on-chain enumeration of tokens
  - **Ownable.sol** — extension to restrict access to certain functions
 
-The mintable ERC721 OpenZeppelin token contract provides a `mint` function that can only be called by the owner of the contract. By default, the owner is the contract's deployer address.
+The mintable ERC-721 OpenZeppelin token contract provides a `mint` function that can only be called by the owner of the contract. By default, the owner is the contract's deployer address.
 
-As with the [ERC20 contract](#deploying-an-erc20-token), the first step is to go to [Remix](https://remix.ethereum.org/) and create a new file. For this example, the file name will be `ERC721.sol`.
+As with the [ERC-20 contract](#deploying-an-erc-20-token), the first step is to go to [Remix](https://remix.ethereum.org/) and create a new file. For this example, the file name will be `ERC721.sol`.
 
 Next, you'll need to write the smart contract and compile it. For this example, the following code is used:
 
@@ -168,7 +168,7 @@ contract MyToken is ERC721, ERC721Enumerable, ERC721Burnable, Ownable {
 }
 ```
 
-This ERC721 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting the `Base URI` as `Test` and activating the `Mintable`, `Burnable`, and `Enumerable` features.
+This ERC-721 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting the `Base URI` as `Test` and activating the `Mintable`, `Burnable`, and `Enumerable` features.
 
 With the contract compiled, head to the "Deploy & Run Transactions" tab. In here, you need to:
 
@@ -177,23 +177,23 @@ With the contract compiled, head to the "Deploy & Run Transactions" tab. In here
  3. If everything is ready, click on the "Deploy" button. Review the transaction information in MetaMask and confirm it
  4. After a few seconds, the transaction should get confirmed, and you should see your contract under "Deployed Contracts"
 
-![Deploy ERC721 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-4.png)
+![Deploy ERC-721 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-4.png)
 
-And that is it! You've deployed an ERC721 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix, or add it to MetaMask.
+And that is it! You've deployed an ERC-721 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix, or add it to MetaMask.
 
-### Deploying an ERC1155 Token {: #deploying-an-erc1155-token } 
+### Deploying an ERC-1155 Token {: #deploying-an-erc-1155-token } 
 
-For this example, an ERC1155 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
+For this example, an ERC-1155 token will be deployed to Moonbase Alpha. The final code used combines different contracts from OpenZeppelin:
 
- - **ERC1155** — ERC1155 token implementation with the optional features from the base interface. Includes the supply mechanism with a `_mint` function but needs to be explicitly called from within the main contract
+ - **ERC-1155** — ERC-1155 token implementation with the optional features from the base interface. Includes the supply mechanism with a `_mint` function but needs to be explicitly called from within the main contract
  - **Pausable** — extension to allows pausing tokens transfer, mintings and burnings
  - **Ownable.sol** — extension to restrict access to certain functions
 
-OpenZeppelin's ERC1155 token contract provides a `_mint` function that can only be called in the `constructor` function. Therefore, this example creates 1000 tokens with an ID of `0`, and 1 unique token with an ID of `1`.
+OpenZeppelin's ERC-1155 token contract provides a `_mint` function that can only be called in the `constructor` function. Therefore, this example creates 1000 tokens with an ID of `0`, and 1 unique token with an ID of `1`.
 
 The first step is to go to [Remix](https://remix.ethereum.org/) and create a new file. For this example, the file name will be `ERC1155.sol`.
 
-As shown for the [ERC20 token](#deploying-an-erc20-token), you'll need to write the smart contract and compile it. For this example, the following code is used:
+As shown for the [ERC-20 token](#deploying-an-erc-20-token), you'll need to write the smart contract and compile it. For this example, the following code is used:
 
 ```solidity
 pragma solidity ^0.8.0;
@@ -230,7 +230,7 @@ contract MyToken is ERC1155, Ownable, Pausable {
 }
 ```
 
-This ERC1155 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting no `Base URI` and activating `Pausable` feature. The constructor function was modified to include the minting of both a fungible and a non-fungible token.
+This ERC-1155 token smart contract was extracted from the [Contract Wizard](#openzeppelin-contract-wizard), setting no `Base URI` and activating `Pausable` feature. The constructor function was modified to include the minting of both a fungible and a non-fungible token.
 
 With the contract compiled, head to the "Deploy & Run Transactions" tab. In here, you need to:
 
@@ -239,6 +239,6 @@ With the contract compiled, head to the "Deploy & Run Transactions" tab. In here
  3. If everything is ready, click on the "Deploy" button. Review the transaction information in MetaMask and confirm it
  4. After a few seconds, the transaction should get confirmed, and you should see your contract under "Deployed Contracts"
 
-![Deploy ERC1155 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-5.png)
+![Deploy ERC-1155 Contract with Remix](/images/builders/interact/oz-remix/oz-contracts-5.png)
 
-And that is it! You've deployed an ERC1155 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix.
+And that is it! You've deployed an ERC-1155 token contract using OpenZeppelin's contracts and libraries. Next, you can interact with your token contract via Remix.

--- a/builders/interact/remix.md
+++ b/builders/interact/remix.md
@@ -91,7 +91,7 @@ After you press confirm and the deployment is complete, you will see the transac
 
 Once the contract is deployed, you can interact with it from within Remix.
 
-Drill down on the contract under “Deployed Contracts.” Clicking on name, symbol, and totalSupply should return “MyToken,” “MYTOK,” and “8000000000000000000000000” respectively. If you copy the address from which you deployed the contract and paste it into the balanceOf field, you should see the entirety of the balance of the ERC20 as belonging to that user. Copy the contract address by clicking the button next to the contract name and address.
+Drill down on the contract under “Deployed Contracts.” Clicking on name, symbol, and totalSupply should return “MyToken,” “MYTOK,” and “8000000000000000000000000” respectively. If you copy the address from which you deployed the contract and paste it into the balanceOf field, you should see the entirety of the balance of the ERC-20 as belonging to that user. Copy the contract address by clicking the button next to the contract name and address.
 
 ![Interact with the contract from Remix](/images/builders/interact/remix/using-remix-11.png)
 
@@ -139,7 +139,7 @@ Once you've added the plugin, a Moonbeam logo will appear on the left hand side,
 
 ### Getting Started with the Moonbeam Remix Plugin
 
-Click on the Moonbeam Logo in your Remix IDE to open the Moonbeam Plugin. This part assumes you already have a contract in Remix ready to be compiled. You can generate an [ERC-20 contract here.](https://wizard.openzeppelin.com/)  Follow along to deploy an ERC-20 Token to Moonbase Alpha using the Moonbeam Remix Plugin.
+Click on the Moonbeam Logo in your Remix IDE to open the Moonbeam Plugin. This part assumes you already have a contract in Remix ready to be compiled. You can generate an [ERC-20 contract here](https://wizard.openzeppelin.com/). Follow along to deploy an ERC-20 Token to Moonbase Alpha using the Moonbeam Remix Plugin.
 
  1. Press "Connect" to Connect your Metamask to the Remix IDE
  2. Ensure you're on the correct network. In this example, we're on Moonbase Alpha

--- a/builders/interact/waffle-mars.md
+++ b/builders/interact/waffle-mars.md
@@ -50,7 +50,7 @@ npm install ethereum-waffle ethereum-mars ethers \
     - [Waffle](https://github.com/EthWorks/Waffle) - for writing, compiling, and testing smart contracts
     - [Mars](https://github.com/EthWorks/Mars) - for deploying smart contracts to Moonbeam
     - [Ethers](https://github.com/ethers-io/ethers.js/) - for interacting with Moonbeam's Ethereum API
-    - [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) - the contract you'll be creating will use OpenZeppelin's ERC20 base implementation
+    - [OpenZeppelin Contracts](https://github.com/OpenZeppelin/openzeppelin-contracts) - the contract you'll be creating will use OpenZeppelin's ERC-20 base implementation
     - [TypeScript](https://github.com/microsoft/TypeScript) - the project will be a TypeScript project
     - [TS Node](https://github.com/TypeStrong/ts-node) - for executing the deployment script you'll create later in this guide
     - [Chai](https://github.com/chaijs/chai) - an assertion library used alongside Waffle for writing tests
@@ -106,7 +106,7 @@ contract MyToken is ERC20 {
 }
 ```
 
-In this contract, you are creating an ERC20 token called MyToken with the symbol MYTOK, that allows you, as the contract creator, to mint as many MYTOKs as desired.
+In this contract, you are creating an ERC-20 token called MyToken with the symbol MYTOK, that allows you, as the contract creator, to mint as many MYTOKs as desired.
 
 ## Use Waffle to Compile and Test {: #use-waffle-to-compile-and-test } 
 

--- a/builders/tools/explorers.md
+++ b/builders/tools/explorers.md
@@ -8,7 +8,7 @@ description: An overview of the currently available block explorers that may be 
 
 ## Introduction {: #introduction } 
 
-Block explorers can be thought of as search engines for the blockchain. They allow users to search information such as balances, contracts, and transactions. More advanced block explorers even offer indexing capabilities, which enable them to provide a complete set of information, such as ERC20 tokens in the network. They might even offer API services to access it via external services.
+Block explorers can be thought of as search engines for the blockchain. They allow users to search information such as balances, contracts, and transactions. More advanced block explorers even offer indexing capabilities, which enable them to provide a complete set of information, such as ERC-20 tokens in the network. They might even offer API services to access it via external services.
 
 Moonbeam provides two different sets of explorers: one to query the Ethereum API, and one for the Substrate API.
 
@@ -38,7 +38,7 @@ As main features, Blockscout offers:
  - Open source development, meaning all code is open to the community to explore and improve. You can find the code [here](https://github.com/blockscout/blockscout)
  - Real-time transaction tracking
  - Smart contract interaction
- - ERC20 and ERC721 token support, listing all available token contract in a friendly interface
+ - ERC-20 and ERC-721 token support, listing all available token contract in a friendly interface
  - Full-featured API with GraphQL, where users can test API calls directly from a web interface
 
 An instance of Blockscout running against the Moonbase Alpha TestNet can be found in [this link](https://moonbase-blockscout.testnet.moonbeam.network/).

--- a/builders/tools/multisig-safe.md
+++ b/builders/tools/multisig-safe.md
@@ -1,6 +1,6 @@
 ---
 title: Moonbeam Safe
-description: Learn how to use and manage funds with the Moonbeam Safe. Create a new multisig safe and receive and send tokens to the safe, as well as ERC20s, on Moonbeam.
+description: Learn how to use and manage funds with the Moonbeam Safe. Create a new multisig safe and receive and send tokens to the safe, as well as ERC-20s, on Moonbeam.
 ---
 
 # Interacting with Moonbeam Safe
@@ -15,11 +15,11 @@ To solve this problem, multi-signature wallets, or multisig for short, have been
 
 To help manage singlesig and multisig wallets, [Gnosis Safe](https://gnosis-safe.io/) was forked to create [Moonbeam Safe](https://multisig.moonbeam.network/). The Safe can be configured as a multisig contract that allows two or more owners to hold and transfer funds to and from the Safe. You can also configure the Safe to be a singlesig contract with only one owner. 
 
-This guide will show you how to create a multisig Safe on the Moonbase Alpha TestNet. You will also learn how to send DEV and ERC20 tokens to and from the Safe, and how to interact with smart contracts using the Safe. This guide can be adapted for Moonriver. 
+This guide will show you how to create a multisig Safe on the Moonbase Alpha TestNet. You will also learn how to send DEV and ERC-20 tokens to and from the Safe, and how to interact with smart contracts using the Safe. This guide can be adapted for Moonriver. 
 
 ## Checking Prerequisites
 
-Before diving into the guide, you'll need to have a few [MetaMask accounts](#metamask-accounts) loaded up with funds, some [ERC20 tokens](#erc20-tokens) on hand to send to the Safe, and a [deployed smart contract](#deployed-smart-contract) to interact with.
+Before diving into the guide, you'll need to have a few [MetaMask accounts](#metamask-accounts) loaded up with funds, some [ERC-20 tokens](#erc-20-tokens) on hand to send to the Safe, and a [deployed smart contract](#deployed-smart-contract) to interact with.
 
 ### MetaMask Accounts
 
@@ -36,9 +36,9 @@ This guide will use the following accounts:
  - **Bob** — 0x3Cd0A705a2DC65e5b1E1205896BaA2be8A07c6e0
  - **Charlie** — 0x798d4Ba9baf0064Ec19eB4F0a1a45785ae9D6DFc
 
-### ERC20 Tokens
+### ERC-20 Tokens
 
-Later on in this guide, you will be learning how to send and receive ERC20 tokens to and from the Safe. So you will need to have deployed some ERC20 tokens and added them to your MetaMask account. To do so, you can check out the [Using Remix to Deploy to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/) guide, in particular the [Deploying a Contract to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/#deploying-a-contract-to-moonbeam-using-remix) and [Interact with a Moonbeam-based ERC20](https://docs.moonbeam.network/builders/interact/remix/#interacting-with-a-moonbeam-based-erc-20-from-metamask) sections will show you how to deploy an ERC20 token and import it into MetaMask.
+Later on in this guide, you will be learning how to send and receive ERC-20 tokens to and from the Safe. So you will need to have deployed some ERC-20 tokens and added them to your MetaMask account. To do so, you can check out the [Using Remix to Deploy to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/) guide, in particular the [Deploying a Contract to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/#deploying-a-contract-to-moonbeam-using-remix) and [Interact with a Moonbeam-based ERC-20](https://docs.moonbeam.network/builders/interact/remix/#interacting-with-a-moonbeam-based-erc-20-from-metamask) sections will show you how to deploy an ERC-20 token and import it into MetaMask.
 
 ### Deployed Smart Contract
 
@@ -209,11 +209,11 @@ The transaction will be removed from the **QUEUE** tab and a record of the trans
 
 Congratulations, you've successfully received and sent DEV tokens to and from the Safe!
 
-## Receive and Send ERC20 Tokens
+## Receive and Send ERC-20 Tokens
 
-### Receive ERC20 Tokens
+### Receive ERC-20 Tokens
 
-Next up is to receive and send ERC20s to and from the Safe. You should already have loaded up your MetaMask with **MYTOK** ERC20 tokens. If not, please refer back to the [ERC20 Tokens](#erc20-tokens) section of the prerequisites.
+Next up is to receive and send ERC-20s to and from the Safe. You should already have loaded up your MetaMask with **MYTOK** ERC-20 tokens. If not, please refer back to the [ERC-20 Tokens](#erc-20-tokens) section of the prerequisites.
 
 You should still be connected to Bob's account for this example. So, you'll be sending MYTOK tokens from Bob's account to the Safe.
 
@@ -226,17 +226,17 @@ You'll need to get the Safe's address again, you can do so by clicking on the **
  5. Click **Next**
  6. Review the transaction details and then click **Confirm** to send the transaction.
 
-![Send ERC20s to the Safe](/images/builders/tools/multisig-safe/safe-18.png)
+![Send ERC-20s to the Safe](/images/builders/tools/multisig-safe/safe-18.png)
 
 If you navigate back to the Safe, in the list of **Assets** you should now see **MyToken** and a balance of 1000 MYTOKs. It could take a few minutes for **MyToken** to appear, but there is nothing for you to do to add the asset, it will appear on it's own.
 
-### Send ERC20 Tokens
+### Send ERC-20 Tokens
 
 Now that you have loaded your Safe with MYTOKs, you can send some from the Safe to another account. For this example, you can send 10 MYTOKs to Charlie.  
 
 Hover over **MyToken** in the list of assets, and this time click on **Send**.
 
-![Send ERC20s from the Safe](/images/builders/tools/multisig-safe/safe-19.png)
+![Send ERC-20s from the Safe](/images/builders/tools/multisig-safe/safe-19.png)
 
 A pop-up will appear where you can enter the recipient and the amount of MYTOK tokens to send:
 
@@ -245,14 +245,14 @@ A pop-up will appear where you can enter the recipient and the amount of MYTOK t
  3. Enter 10 MYTOK tokens
  4. Click **Review** and review the details
 
-![Send ERC20s to Charlie from the Safe](/images/builders/tools/multisig-safe/safe-20.png)
+![Send ERC-20s to Charlie from the Safe](/images/builders/tools/multisig-safe/safe-20.png)
 
 If everything looks ok, you can:
 
  1. Click **Submit**. MetaMask will pop-up and you'll notice that instead of sending a transaction, you're sending a message
  2. Click **Sign** to sign the message
 
-![Sign Message to Send ERC20s to Charlie from the Safe](/images/builders/tools/multisig-safe/safe-21.png)
+![Sign Message to Send ERC-20s to Charlie from the Safe](/images/builders/tools/multisig-safe/safe-21.png)
 
 Now, if you go back to the Safe, under the **Transactions** tab, you should be able to see that there has been a transaction proposal initiated to send 10 MYTOK tokens to Charlie's address. However, you should also see that only 1 out of 2 confirmations have been received and that 1 more owner is required to confirm the transaction before it gets executed.
 
@@ -264,7 +264,7 @@ Once the transaction has been confirmed from one of the other two accounts, the 
 
 ![Successfully Executed Transaction](/images/builders/tools/multisig-safe/safe-23.png)
 
-Congratulations! You've successfully received and sent ERC20 tokens to and from the Safe!
+Congratulations! You've successfully received and sent ERC-20 tokens to and from the Safe!
 
 ## Interact with a Smart Contract
 

--- a/builders/tools/openzeppelin/overview.md
+++ b/builders/tools/openzeppelin/overview.md
@@ -9,7 +9,7 @@ description:  Learn how to use OpenZeppelin products on Moonbeam thanks to its E
 
 ## Introduction {: #introduction } 
 
-OpenZeppelin is well known in the Ethereum developer community as their set of audited smart contracts and libraries are a standard in the industry. For example, most of the tutorials that show developers how to deploy an ERC20 token use OpenZeppelin contracts.
+OpenZeppelin is well known in the Ethereum developer community as their set of audited smart contracts and libraries are a standard in the industry. For example, most of the tutorials that show developers how to deploy an ERC-20 token use OpenZeppelin contracts.
 
 You can find more information about OpenZeppelin in their [website](https://openzeppelin.com/) or [documentation site](https://docs.openzeppelin.com/openzeppelin/).
 
@@ -28,6 +28,6 @@ Currently, the following OpenZeppelin products/solutions work on the different n
 You will find a corresponding tutorial for each product in the following links:
 
  - [**Contract Wizard**](/builders/interact/oz-remix/#openzeppelin-contract-wizard) — where you'll find a guide on how to use OpenZeppelin web-based wizard to create different token contracts with different functionalities
- - [**Contracts & Libraries**](/builders/interact/oz-remix/#deploying-openzeppelin-contracts-on-moonbeam) — where you'll find tutorials to deploy the most common token contracts using OpenZeppelin's templates: ERC20, ERC721 and ERC1155
+ - [**Contracts & Libraries**](/builders/interact/oz-remix/#deploying-openzeppelin-contracts-on-moonbeam) — where you'll find tutorials to deploy the most common token contracts using OpenZeppelin's templates: ERC-20, ERC-721 and ERC-1155
  - [**Defender**](/builders/tools/openzeppelin/defender/) — where you'll find a guide on how to use OpenZeppelin Defender to manage your smart contracts in the Moonbase Alpha TestNet
 

--- a/learn/features/staking.md
+++ b/learn/features/staking.md
@@ -35,7 +35,7 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
     - **Collator information** — list of collators: [Moonriver Subscan](https://moonriver.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners?network=Moonriver)
-    - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver)
+    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonriver)
 
 === "Moonbase Alpha" 
 
@@ -51,7 +51,7 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
     - **Collator information** — list of collators: [Moonbase Alpha Subscan](https://moonbase.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners?network=MoonbaseAlpha)
-    - **Manage staking related actions** — visit the [Moonbeam Network dApp](https://apps.moonbeam.network/moonbase-alpha)
+    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonbase-alpha)
 
 To learn how to get the current value of any of the parameters around staking, check out the [Retrieving Staking Parameters](/tokens/staking/stake/#retrieving-staking-parameters) section of the [How to Stake your Tokens](/tokens/staking/stake/) guide. 
 
@@ -81,4 +81,4 @@ Where `amount_due` is the corresponding inflation being distributed in a specifi
 
 ## Try it out {: #try-it-out } 
 
-You can start interacting with staking functions on Moonriver and Moonbase Alpha through the [Moonbeam Network dApp](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).
+You can start interacting with staking functions on Moonriver and Moonbase Alpha through the [Moonbeam Network DApp](https://apps.moonbeam.network/moonriver). To do so, you can check [this guide](https://moonbeam.network/tutorial/stake-movr/) or [this video tutorial](https://www.youtube.com/watch?v=maIfN2QkPpc).

--- a/tokens/connect/ledger.md
+++ b/tokens/connect/ledger.md
@@ -140,6 +140,6 @@ However, if you want to use your Ledger hardware wallet for transactions related
  4. Select/validate the option to change its value to **Enabled**
 
 !!! note
-    This option is necessary to use your Ledger device to interact with ERC20 token contracts that might live inside the Moonbeam ecosystem.
+    This option is necessary to use your Ledger device to interact with ERC-20 token contracts that might live inside the Moonbeam ecosystem.
 
 ![MetaMask Ledger Allow Contracts Tx](/images/tokens/connect/ledger/ledger-11.png)

--- a/tokens/connect/metamask.md
+++ b/tokens/connect/metamask.md
@@ -26,7 +26,7 @@ If you already have MetaMask installed, you can easily connect MetaMask to the n
 !!! note
     MetaMask will popup asking for permission to add a a custom network. Once you approve permissions, MetaMask will switch your current network.
 
-Learn [how to integrate a Connect MetaMask button](/builders/interact/metamask-dapp/) into your dapp, so that users can connect to Moonbase Alpha with a simple click of a button.
+Learn [how to integrate a Connect MetaMask button](/builders/interact/metamask-dapp/) into your DApp, so that users can connect to Moonbase Alpha with a simple click of a button.
 
 ## Video Tutorials
 


### PR DESCRIPTION
We were using ERC20 and ERC-20, so changed all references of ERC* to ERC-*

Noticed when I went to go update the [Moonbeam Docs Standards](https://purestake.atlassian.net/wiki/spaces/MOON/pages/1326383211/Moonbeam+Docs+Standards) that we also should be using DApps instead of dApps, so updated that too!