### PR TITLE
Update Block Explorers on the Moonriver and Moonbase Alpha Network pages

### DIFF
--- a/builders/get-started/moonbase.md
+++ b/builders/get-started/moonbase.md
@@ -11,10 +11,11 @@ description: The Moonbeam TestNet, named Moonbase Alpha, is the easiest way to g
 
 For Moonbase Alpha, you can use any of the following block explorers:
 
- - **Substrate API** — [Subscan](https://moonbase.subscan.io/) or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.testnet.moonbeam.network#/explorer)
- - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha)
- - **Ethereum API with Indexing** — [Blockscout](https://moonbase-blockscout.testnet.moonbeam.network/)
-
+ - **Ethereum API (Etherscan Equivalent)** — [Moonscan](https://moonbase.moonscan.io/){target=_blank}
+ - **Ethereum API with Indexing** — [Blockscout](https://moonbase-blockscout.testnet.moonbeam.network/){target=_blank}
+ - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbaseAlpha){target=_blank}
+ - **Substrate API** — [Subscan](https://moonbase.subscan.io/){target=_blank} or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.testnet.moonbeam.network#/explorer){target=_blank}
+ 
 For more information on each of the available block explorers, please head to the [Block Explorers](/builders/tools/explorers) section of the documentation.
 
 ## Connect MetaMask

--- a/builders/get-started/moonriver.md
+++ b/builders/get-started/moonriver.md
@@ -11,9 +11,12 @@ description: Learn how to get started and connect to Moonriver, the Moonbeam dep
 
 For Moonriver, you can use any of the following block explorers:
 
- - **Substrate API** — [Subscan](https://moonriver.subscan.io/) or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.moonriver.moonbeam.network#/explorer)
- - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonriver)
- - **Ethereum API with Indexing** — [Blockscout](https://blockscout.moonriver.moonbeam.network/)
+ - **Ethereum API (Etherscan Equivalent)** — [Moonscan](https://moonriver.moonscan.io/){target=_blank}
+ - **Ethereum API with Indexing** — [Blockscout](https://blockscout.moonriver.moonbeam.network/){target=_blank}
+ - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=Moonriver){target=_blank}
+ - **Substrate API** — [Subscan](https://moonriver.subscan.io/){target=_blank} or [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.moonriver.moonbeam.network#/explorer){target=_blank}
+ 
+ 
 
 For more information on each of the available block explorers, please head to the [Block Explorers](/builders/tools/explorers) section of the documentation.
 

--- a/learn/features/staking.md
+++ b/learn/features/staking.md
@@ -34,8 +34,9 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Nominators reward pool** — {{ networks.moonriver.staking.nominator_reward_inflation }}% of the annual inflation
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
-    - **Collator information** — list of collators: [Moonriver Subscan](https://moonriver.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners?network=Moonriver)
-    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonriver)
+    - **Collator information** — a list of Moonriver collators is available on [Subscan](https://moonriver.subscan.io/validator){target=_blank}. A collator performance leaderboard is accessible on [Moonscan](https://moonriver.moonscan.io/collators){target=_blank}
+    - **Collator APY Info** - [DappLooker Collator Dashboard](http://analytics.dapplooker.com/public/dashboard/7dfc5a6e-da33-4d54-94bf-0dfa5e6843cb){target=_blank} *Warning! This dashboard is experimental beta software and may not accurately reflect collator performance. Be sure to do your own research before delegating to a collator* 
+    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonriver){target=_blank}
 
 === "Moonbase Alpha" 
 
@@ -50,8 +51,8 @@ Collators (and token holders if they nominate) have a stake in the network. The 
     - **Nominators reward pool** — {{ networks.moonbase.staking.nominator_reward_inflation }}% of the annual  inflation
     - **Nominator rewards** — variable. It's the aggregate nominator rewards distributed over all eligible nominators, taking into account the relative size of stakes ([read more](/staking/overview/#reward-distribution))
     - **Slashing** — currently, there is no slashing. This can be later changed through governance. Collators who produce blocks that are not finalized by the relay chain won't receive rewards
-    - **Collator information** — list of collators: [Moonbase Alpha Subscan](https://moonbase.subscan.io/validator). Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners?network=MoonbaseAlpha)
-    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonbase-alpha)
+    - **Collator information** — a list of Moonbase Alpha collators is available on [Subscan](https://moonbase.subscan.io/validator){target=_blank}. Collator data for the last two rounds: [Moonbeam Explorer](https://moonbeam-explorer.netlify.app/stats/miners?network=MoonbaseAlpha){target=_blank}
+    - **Manage staking related actions** — visit the [Moonbeam Network DApp](https://apps.moonbeam.network/moonbase-alpha){target=_blank}
 
 To learn how to get the current value of any of the parameters around staking, check out the [Retrieving Staking Parameters](/tokens/staking/stake/#retrieving-staking-parameters) section of the [How to Stake your Tokens](/tokens/staking/stake/) guide. 
 

--- a/variables.yml
+++ b/variables.yml
@@ -11,7 +11,7 @@ networks:
     chain_id: 1287
     hex_chain_id: '0x507'
     chain_spec: alphanet
-    block_explorer: https://moonbase-blockscout.testnet.moonbeam.network/
+    block_explorer: https://moonbase.moonscan.io/
     parachain_release_tag: v0.15.1 # must be in this exact format for links to work
     parachain_sha256sum: c08e5f55bfc1dc7e2eec47727f0e710bc112f64b04c96843874e2f22a9badcd6
     gas_block: 15M
@@ -133,7 +133,7 @@ networks:
     parachain_release_tag: v0.15.1
     parachain_sha256sum: c08e5f55bfc1dc7e2eec47727f0e710bc112f64b04c96843874e2f22a9badcd6
     chain_spec: moonriver
-    block_explorer: https://blockscout.moonriver.moonbeam.network/
+    block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam
     min_gas_price: 1
     block_time: 12


### PR DESCRIPTION
Quick PR to include the following:

- Update default block explorer variable to Moonscan (applicable such as when Adding a new Network in Metamask)
- Add Moonscan to the List of block explorers on the Moonbase Alpha and Moonriver network pages
- Add Collator Performance leaderboard
- Add DappLooker Dashboard Link