### PR TITLE
Separate entries for nominators and delegators on glossary page

### DIFF
--- a/learn/platform/glossary.md
+++ b/learn/platform/glossary.md
@@ -11,9 +11,13 @@ There's a great deal of terminology that's specific to Polkadot, Substrate, and 
 
 One of the key network participants needed to support parachains within the Polkadot Network.  In Moonbeam, collators are the nodes that are responsible for block production and for submitting produced blocks up to the Polkadot relay chain for finalization.
 
-### Delegators (Nominators) {: #delegators } 
+### Delegators {: #delegators } 
 
-Token holders who select to "back" a validator. They can receive part of the validator's reward, but are subject to slashing of their staked tokens in case the validator misbehaves. A delegator can back up to 16 validators, and their bond is fully distributed between the backed validators that were selected for the validator set. If you want to delegate PureStake for both Polkadot and/or Kusama, please check out PureStake's [Validator Services](https://www.purestake.com/technology/polkadot-validator/) guides.
+Moonbeam token holders who stake tokens, vouching for specific collator candidates on the parachain. Any user that holds a minimum amount of tokens as [free balance](https://wiki.polkadot.network/docs/learn-accounts#balance-types) can become a delegator by staking their tokens. 
+
+### Nominators {: #nominators } 
+
+Relay chain token holders who select to "back" a validator. They can receive part of the validator's reward, but are subject to slashing of their staked tokens in case the validator misbehaves. A nominator can back up to 16 validators, and their bond is fully distributed between the backed validators that were selected for the validator set. If you want to nominate PureStake for both Polkadot and/or Kusama, please check out PureStake's [Validator Services](https://www.purestake.com/technology/polkadot-validator/) guides.
 
 ### Nominated Proof of Stake {: #nominated-proof-of-stake } 
 


### PR DESCRIPTION
Update glossary.md to have separate entries for nominators and delegators on the glossary page. 