### PR TITLE
Fix VMP>DMP definition in overview.md

### DIFF
--- a/builders/xcm/overview.md
+++ b/builders/xcm/overview.md
@@ -18,7 +18,7 @@ Polkadot implements two cross-consensus or transport protocols for acting on XCM
 - **Vertical Message Passing (VMP)** — divided into two kinds of message-passing transport protocols:
 
     * **Upward Message Passing (UMP)** — allows parachains to send messages to their relay chain, for example, from Moonbeam to Polkadot
-    * **Downward Message Passing (DMP)** — allows two parachains to exchange messages as long as they are connected to the same relay chain. Cross-chain transactions are resolved using a simple queuing mechanism based on a Merkle tree to ensure fidelity
+    * **Downward Message Passing (DMP)** — allows the relay chain to pass messages down to one of their parachains, for example, from Polkadot to Moonbeam
 
 - **Cross-Chain Message Passing (XCMP)** — allows two parachains to exchange messages as long as they are connected to the same relay chain. Cross-chain transactions are resolved using a simple queuing mechanism based on a Merkle tree to ensure fidelity. Collators exchange messages between parachains, while the relay chain validators will verify that the message transmission happened
 


### PR DESCRIPTION
### Description

Definition of DMP was incorrect based on https://wiki.polkadot.network/docs/learn-crosschain documentation

Only English version of the page exist - no need for any translation
