### PR TITLE
fix the relay chain snippet

### DIFF
--- a/snippets/code/endpoints/moonbase.md
+++ b/snippets/code/endpoints/moonbase.md
@@ -23,8 +23,3 @@
     ```
 
 --8<-- 'text/testnet/relay-chain.md'
-
-=== "PureStake"
-    ```
-    wss://wss-relay.testnet.moonbeam.network
-    ```

--- a/snippets/text/testnet/connect.md
+++ b/snippets/text/testnet/connect.md
@@ -41,8 +41,4 @@ Moonbase Alpha TestNet chain ID is: `1287`, which is `0x507` in hex.
 
 ### Relay Chain {: #relay-chain } 
 
-To connect to the Moonbase Alpha relay chain, managed by PureStake, you can use the following WS Endpoint:
-
-```
-wss://wss-relay.testnet.moonbeam.network
-```
+--8<-- 'text/testnet/relay-chain.md

--- a/snippets/text/testnet/relay-chain.md
+++ b/snippets/text/testnet/relay-chain.md
@@ -1,1 +1,6 @@
 To connect to the Moonbase Alpha relay chain, you can use the following WS Endpoint:
+
+=== "PureStake"
+    ```
+    wss://wss-relay.testnet.moonbeam.network
+    ```


### PR DESCRIPTION
### Description

This PR fixes the relay chain snippets... if you go to https://docs.moonbeam.network/snippets/text/testnet/relay-chain/ the actual endpoint isn't there haha

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If images have been moved, I have created an additional PR in `moonbeam-docs-cn` to update images to their new paths
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [x] no translations required

### Corresponding PRs

https://github.com/PureStake/moonbeam-docs-cn/pull/41

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a