### PR TITLE
add moonbeam as an option to the multisig page

### DIFF
--- a/builders/tools/multisig-safe.md
+++ b/builders/tools/multisig-safe.md
@@ -13,9 +13,9 @@ A single-signature wallet, or singlesig for short, is a wallet in which only one
 
 To solve this problem, multi-signature wallets, or multisig for short, have been introduced. With a multisig wallet there is more than one owner, so one owner could lose their keys and the others would still have access to the wallet and funds. In addition, multisig wallets can require threshold signing, where a proposal is only executed as a transaction if a certain amount of approvals are attained. Therefore creating an extra layer of security.
 
-To help manage singlesig and multisig wallets, [Gnosis Safe](https://gnosis-safe.io/) was forked to create [Moonbeam Safe](https://multisig.moonbeam.network/). The Safe can be configured as a multisig contract that allows two or more owners to hold and transfer funds to and from the Safe. You can also configure the Safe to be a singlesig contract with only one owner. 
+To help manage singlesig and multisig wallets, [Gnosis Safe](https://gnosis-safe.io/){target=blank} was forked to create [Moonbeam Safe](https://multisig.moonbeam.network/){target=blank}. The Safe can be configured as a multisig contract that allows two or more owners to hold and transfer funds to and from the Safe. You can also configure the Safe to be a singlesig contract with only one owner. 
 
-This guide will show you how to create a multisig Safe on the Moonbase Alpha TestNet. You will also learn how to send DEV and ERC-20 tokens to and from the Safe, and how to interact with smart contracts using the Safe. This guide can be adapted for Moonriver. 
+This guide will show you how to create a multisig Safe on the Moonbase Alpha TestNet. You will also learn how to send DEV and ERC-20 tokens to and from the Safe, and how to interact with smart contracts using the Safe. This guide can be adapted for Moonbeam and Moonriver.
 
 ## Checking Prerequisites
 
@@ -42,9 +42,9 @@ Later on in this guide, you will be learning how to send and receive ERC-20 toke
 
 ### Deployed Smart Contract
 
-Towards the end of this guide, you will be learning how to interact with a smart contract using the Safe. So you will need to have a smart contract deployed to interact with. If you would like detailed instructions, you can refer to the [Deploying a Contract to Moonbeam using Remix](/builders/tools/remix/#deploying-a-contract-to-moonbeam) guide. 
+Towards the end of this guide, you will be learning how to interact with a smart contract using the Safe. So you will need to have a smart contract deployed to interact with. If you would like detailed instructions, you can refer to the [Deploying a Contract to Moonbeam using Remix](/builders/tools/remix/#deploying-a-contract-to-moonbeam){target=blank} guide. 
 
-You can head to [Remix](https://remix.ethereum.org/) and create a new file for the following `SetText.sol` contract:
+You can head to [Remix](https://remix.ethereum.org/){target=blank} and create a new file for the following `SetText.sol` contract:
 
 ```
 pragma solidity ^0.8.0;
@@ -64,11 +64,11 @@ You will need the contract address and the ABI, so make sure you have copied tho
 
 ## Create a Safe 
 
-To get started creating a Safe, navigate to the [Moonbeam Safe](https://multisig.moonbeam.network/moonbase). For the purpose of this guide, you'll create a Safe on Moonbase Alpha, but you can also adapt the instructions to create a [Safe on Moonriver](https://multisig.moonbeam.network/moonriver). To switch networks, simply click the network dropdown in the top right hand corner of the page. 
+To get started creating a Safe, navigate to the [Moonbeam Safe](https://multisig.moonbeam.network/moonbase){target=blank}. For the purpose of this guide, you'll create a Safe on Moonbase Alpha, but you can also adapt the instructions to create a Safe on [Moonbeam](https://multisig.moonbeam.network/moonbeam){target=blank} or [Moonriver](https://multisig.moonbeam.network/moonriver){target=blank}. To switch networks, simply click the network dropdown in the top right hand corner of the page. 
 
 ### Connect MetaMask
 
-Once on the [Moonbase Alpha](https://multisig.moonbeam.network/moonbase/) page, you can begin to create a Safe by first connecting your wallet:
+Once on the [Moonbase Alpha](https://multisig.moonbeam.network/moonbase/){target=blank} page, you can begin to create a Safe by first connecting your wallet:
 
  1. Click **Connect Wallet**
  2. Select a wallet to connect to Moonbeam Safe. For this example you can use MetaMask. If MetaMask doesn't appear in the list of options, click **Show More** and select **MetaMask**
@@ -222,7 +222,7 @@ You'll need to get the Safe's address again, you can do so by clicking on the **
  1. Switch to the **Assets** tab and select **MYTOK** from the list
  2. Click **Send** 
  3. Paste in the Safe's address
- 4. Enter amount of MYTOKs to send. You should have minted 8M MYTOK tokens in the [Using Remix to Deploy to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/) guide. So for this example, you can enter 1000 MYTOKs for the amount to send
+ 4. Enter amount of MYTOKs to send. You should have minted 8M MYTOK tokens in the [Using Remix to Deploy to Moonbeam](https://docs.moonbeam.network/builders/interact/remix/){target=blank} guide. So for this example, you can enter 1000 MYTOKs for the amount to send
  5. Click **Next**
  6. Review the transaction details and then click **Confirm** to send the transaction.
 
@@ -268,7 +268,7 @@ Congratulations! You've successfully received and sent ERC-20 tokens to and from
 
 ## Interact with a Smart Contract
 
-For this section, you will be interacting with a smart contract using the Safe. You should have already deployed the `SetText.sol` contract using Remix, if not please refer back to the [Deployed Smart Contract](#deployed-smart-contract) section of the prerequisites.
+For this section, you will be interacting with a smart contract using the Safe. You should have already deployed the `SetText.sol` contract using Remix, if not please refer back to the [Deployed Smart Contract](#deployed-smart-contract){target=blank} section of the prerequisites.
 
 You should still be connected to Alice's account for this section of the guide.
 


### PR DESCRIPTION
### Description

This PR updates the Moonbeam Safe page to include Moonbeam as an option. It also adds `{target=blank}` to the URLs throughout the page.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If images have been moved, I have created an additional PR in `moonbeam-docs-cn` to update images to their new paths
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a