### PR TITLE
Add check finality RPC endpoints and updates consensus-finality.md

### DIFF
--- a/builders/get-started/eth-compare/consensus-finality.md
+++ b/builders/get-started/eth-compare/consensus-finality.md
@@ -5,7 +5,7 @@ description: A description of the main differences that Ethereum developers need
 
 ![Moonbeam v Ethereum - Consensus and Finality Banner](/images/builders/get-started/eth-compare/consensus-finality-banner.png)
 
-## Introduction
+## Introduction {: #introduction }
 
 While Moonbeam strives to be compatible with Ethereum's Web3 API and EVM, there are some important Moonbeam differences that developers should know and understand in terms of consensus and finality.
 
@@ -15,19 +15,19 @@ At the time of writing, Ethereum uses a consensus protocol based on [Proof-of-Wo
 
 This guide will outline some of these main differences around consensus and finality, and what to expect when using Moonbeam for the first time.
 
-## Ethereum Consensus and Finality
+## Ethereum Consensus and Finality {: #ethereum-consensus-and-finality }
 
 As stated before, Ethereum is currently using a PoW consensus protocol and the longest chain rule, where finality is probabilistic. 
 
 Probabilistic finality means that the probability that a block (and all its transactions) will not be reverted increases as more blocks are built on top of it. Therefore, the higher the number of blocks you wait, the higher the certainty that a transaction will not be re-organized, and consequently reverted. As suggested by [this blog on finality](https://blog.ethereum.org/2016/05/09/on-settlement-finality/) by Vitalik, _"you can wait 13 confirmations for a one-in-a-million chance of the attacker succeeding."_
 
-## Moonbeam Consensus and Finality
+## Moonbeam Consensus and Finality {: #moonbeam-consensus-and-finality }
 
 In Polkadot, there are collators and validators. [Collators](https://wiki.polkadot.network/docs/en/learn-collator) maintain parachains (in this case, Moonbeam) by collecting transactions from users and producing state transition proofs for the Relay Chain [validators](https://wiki.polkadot.network/docs/en/learn-validator). The collator set (nodes that produce blocks) are selected based on the [stake they have in the network](/learn/features/consensus/). 
 
 For finality, Polkadot/Kusama rely on [GRANDPA](https://wiki.polkadot.network/docs/learn-consensus#finality-gadget-grandpa). GRANDPA provides deterministic finality for any given transaction (block). In other words, when a block/transaction is marked as final, it can't be reverted except via on-chain governance or forking. Moonbeam follows this deterministic finality.
 
-## Main Differences
+## Main Differences {: #main-differences }
 
 In terms of consensus, Moonbeam is based on Delegated Proof-of-Stake, while Ethereum relies on Proof-of-Work, which are very different. Consequently, Proof of Work concepts, such as  `difficulty`, `uncles`, `hashrate`, generally don’t have meaning within Moonbeam.
 
@@ -42,61 +42,81 @@ However, the deterministic finality of Moonbeam can be used to provide a better 
 
 The following sections outline how you can check for transaction finality using both the Ethereum JSON-RPC (custom Web3 request) and the Substrate (Polkadot) JSON-RPC.
 
-## Checking Tx Finality with Ethereum Libraries
+## Checking Tx Finality with Moonbeam RPC Endpoints {: #checking-tx-finality-with-moonbeam-rpc-endpoints }
 
-You can make calls to the Substrate JSON-RPC using the `send` method of both [Web3.js](https://web3js.readthedocs.io/) and [Ethers.js](https://docs.ethers.io/).
+Moonbeam has added support for two new RPC endpoints, `moon_isBlockFinalized` and `moon_isTxFinalized` to the Moonbeam node, that are useful for checking whether an on-chain event is finalized. The information on these two endpoints are as follows:
 
-Custom RPC requests are also possible using [Web3.py](https://web3py.readthedocs.io/) with the `make_request` method. You can use the Web3.js example as a baseline.
+=== "moon_isBlockFinalized"
+    |   Variable   |                                      Value                                       |
+    |:------------:|:--------------------------------------------------------------------------------|
+    |   Endpoint |                        `moon_isBlockFinalized`                     |
+    |   Description   | Check for the finality of the block given by its block hash. |
+    |  Parameters |    `block_hash`: **STRING** The hash of the block, accepts either Substrate-style or ethereum-style block hash as its input.                     | 
+    |  Returns | `result`: **BOOLEAN** Returns `True` if the block is finalized, `False` if the block is not finalized or not found.  | 
+
+=== "moon_isTxFinalized"
+    |   Variable   |                                      Value                                       |
+    |:------------:|:--------------------------------------------------------------------------------|
+    |   Endpoint |                        `moon_isTxFinalized`                     |
+    |   Description   | Check for the finality of the transaction given by its EVM tx hash. |
+    |  Parameters | `tx_hash`: **STRING** The EVM tx hash of the transaction.  | 
+    |  Returns |  `result`: **BOOLEAN** Returns `True` if the tx is finalized; `False` if the tx is not finalized or not found. | 
+
+You can try out these endpoints with the following curl examples. These examples query the public RPC endpoint of Moonbase Alpha, but they can be modified to use with Moonbeam and Moonriver by changing the URL of the RPC endpoint to the corresponding [endpoints](https://docs.moonbeam.network/builders/get-started/endpoints/){target=_blank}. 
+
+=== "moon_isBlockFinalized"
+    ```
+    curl -H "Content-Type: application/json" -X POST --data 
+        '[{
+            "jsonrpc":"2.0",
+            "id":"1",
+            "method":"moon_isBlockFinalized",
+            "params":["Put-Block-Hash-Here"
+        ]}]' 
+        https://rpc.api.moonbase.moonbeam.network
+    ```
+
+=== "moon_isTxFinalized"
+    ```
+    curl -H "Content-Type: application/json" -X POST --data 
+        '[{
+            "jsonrpc":"2.0",
+            "id":"1",
+            "method":"moon_isTxFinalized",
+            "params":["Put-Tx-Hash-Here"
+        ]}]' 
+        https://rpc.api.moonbase.moonbeam.network
+    ```
+
+
+## Checking Tx Finality with Ethereum Libraries {: #checking-tx-finality-with-ethereum-libraries }
+
+You can make calls to the Substrate JSON-RPC using the `send` method of both [Web3.js](https://web3js.readthedocs.io/) and [Ethers.js](https://docs.ethers.io/). Custom RPC requests are also possible using [Web3.py](https://web3py.readthedocs.io/) with the `make_request` method. You can use the Web3.js example as a baseline.
+
+The code snippets rely on two custom RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead` and `chain_getHeader`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. The same is true for `eth_getBlockByNumber` and `eth_getTransactionReceipt`, to check if the given transaction hash is included in the block.
 
 !!! note
     The code snippets presented in the following sections are not meant for production environments. Please make sure you adapt it for each use-case.
 
-### Custom RPC Requests with Web3.js
+=== "web3.js"
+    --8<-- 'code/vs-ethereum/web3.md'
 
-With [Web3.js](https://web3js.readthedocs.io/), you can make custom RPC requests with the `web3.currentProvider.send()` method. However, at the time of writing, this was not in the official Web3.js documentation.
+=== "ethers.js"
+    --8<-- 'code/vs-ethereum/ethers.md'
 
-Given a transaction hash (`tx_hash`), the following code snippet uses Web3.js to fetch the current finalized block and compare it with the block number of the transaction you've provided. 
+=== "web3.py"
+    --8<-- 'code/vs-ethereum/web3py.md'
 
-The code relies on two custom RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead` and `chain_getHeader`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. It also uses the same custom RPC function for `eth_getTransactionReceipt`, but this can be modified to use the regular `web3.eth.getTransactionReceipt(hash)` method. The same is true for `eth_getBlockByNumber`, to check if the given transaction hash is included in the block.
+## Checking Tx Finality with Substrate Libraries {: #checking-tx-finality-with-substrate-libraries }
 
---8<-- 'code/vs-ethereum/web3.md'
+The [Polkadot.js API package](https://polkadot.js.org/docs/api/start) and [Python Substrate Interface package](https://github.com/polkascan/py-substrate-interface) provides developers a way to interact with Substrate chains using Javascript and Python.
 
-### Custom RPC Requests with Ethers.js
+Given a transaction hash (`tx_hash`), the following code snippets fetch the current finalized block and compare it with the block number of the transaction you've provided. The code relies on three RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead`, `chain_getHeader` and `eth_getTransactionReceipt`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. The third request is fairly similar to the Ethereum JSON-RPC method, but it is done directly via the Substrate metadata.
 
-With [Ethers.js](https://docs.ethers.io/), you can make custom RPC requests with the `JsonRpcProvider` web3 provider. This will enable the `web3Provider.send()` method, as detailed in their [documentation site](https://docs.ethers.io/v5/api/providers/jsonrpc-provider/#JsonRpcProvider-send).
+You can find more information about Polkadot.js and the Substrate JSON RPC in their [official documentation site](https://polkadot.js.org/docs/substrate/rpc), and more about Python Substrate Interface in their [official documentation site](https://polkascan.github.io/py-substrate-interface/).
 
-Given a transaction hash (`tx_hash`), the following code snippet uses Ethers.js to fetch the current finalized block and compare it with the block number of the transaction you've provided. 
+=== "Polkadot.js"
+    --8<-- 'code/vs-ethereum/polkadotjs.md'
 
-The code relies on two custom RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead` and `chain_getHeader`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. It also uses the same custom RPC function for `eth_getTransactionReceipt`, but this can be modified to use the regular `web3Provider.getTransactionReceipt(hash)` method. The same is true for `eth_getBlockByNumber`, to check if the given transaction hash is included in the block.
-
---8<-- 'code/vs-ethereum/ethers.md'
-
-### Custom RPC Requests with Web3.py
-
-With [Web3.py](https://web3py.readthedocs.io/en/stable/), you can make custom RPC requests with the `JSONBaseProvider()` web3 provider. This will enable the `encode_rpc_request` and `decode_rpc_response` methods. However, at the time of writing, this was not in the official Web3.py documentation.
-
-Given a transaction hash (`tx_hash`), the following code snippet uses Web3.py to fetch the current finalized block and compare it with the block number of the transaction you've provided. 
-
-The code asynchronously calls two custom RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead` and `chain_getHeader`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. It uses the built-in `web3.eth.getTransactionReceipt` method for retrieving the transaction receipt. The same is true for `eth_getBlockByNumber`, to check if the given transaction hash is included in the block.
-
---8<-- 'code/vs-ethereum/web3py.md'
-
-## Checking Tx Finality with Polkadot.js
-
-The [Polkadot.js API package](https://polkadot.js.org/docs/api/start) provides developers a way to interact with Substrate chains using Javascript.
-
-Given a transaction hash (`tx_hash`), the following code snippet uses Polkadot.js to fetch the current finalized block and compare it with the block number of the transaction you've provided. You can find all the available information about Polkadot.js and the Substrate JSON RPC in their [official documentation site](https://polkadot.js.org/docs/substrate/rpc).
-
-The code relies on three RPC requests from the Substrate JSON-RPC: `chain_getFinalizedHead`, `chain_getHeader` and `eth_getTransactionReceipt`. The first request gets the block hash of the last finalized block. The second request gets the block header for a given block hash. The third request is fairly similar to the Ethereum JSON-RPC method, but it is done directly via the Substrate metadata.
-
---8<-- 'code/vs-ethereum/polkadotjs.md'
-
-## Checking Tx Finality with Python Substrate Interface
-
-The [Python Substrate Interface package](https://github.com/polkascan/py-substrate-interface) provides developers a way to interact with Substrate chains using Python. 
-
-Given a transaction hash (`tx_hash`), the following code snippet uses Python Substrate Interface to fetch the current finalized block and compare it with the block number of the transaction you've provided. You can find all the available information about Python Substrate Interface and the available endpoints in their [official documentation site](https://polkascan.github.io/py-substrate-interface/).
-
-The code relies on two RPC requests from the Substrate JSON-RPC: `eth_getTransactionReceipt` and `eth_getBlockByNumber`. The first request gets the Ethereum transaction receipt by tx hash. The second request gets the Ethereum block by block number. 
-
---8<-- 'code/vs-ethereum/pysubstrateinterface.md'
+=== "py-substrate-interface"
+    --8<-- 'code/vs-ethereum/pysubstrateinterface.md'


### PR DESCRIPTION
### Description

Adds the two new Moonbeam RPC endpoints  (https://github.com/PureStake/moonbeam/pull/1184) and sample curls.

Combines the finality checking scripts using various libraries from before into tabbed sections. 

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If images have been moved, I have created an additional PR in `moonbeam-docs-cn` to update images to their new paths
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
