### PR TITLE
Add xc dot

### DIFF
--- a/.snippets/text/xcm/general-xcm-definitions.md
+++ b/.snippets/text/xcm/general-xcm-definitions.md
@@ -1,4 +1,4 @@
-## General XCM Definitions
+## General XCM Definitions {: #general-xcm-definitions }
 
  - **XCM** — stands for cross-consensus message, it is a general way for consesus systems to communicate with eachother
  - **VMP** — stands for vertical message passing, it allows parachains to exchange messages with the relay chain. *UMP* (upward message passing) allows parachains to send messages to their relay chain, while *DMP* (downward message passing) allows the relay chain to pass messages down to one of their parachains

--- a/builders/xcm/overview.md
+++ b/builders/xcm/overview.md
@@ -42,7 +42,7 @@ Furthermore, the two most common use-cases for XCM messages, at least in the ear
 
 A much more detailed article about XCM can be found in the [Polkadot Wiki](https://wiki.polkadot.network/docs/learn-crosschain){target=_blank}.
 
-Initially, Moonbeam will only support remote transfers. All cross-chain assets on Moonbeam will be known as _xc- + TokenName_. For example, Polkadot's DOT representation on Moonbeam is known as _xc-DOT_ and Kusama's KSM representation on Moonriver is _xc-KSM_. You can read more about the XC-20 standard in the [XC-20s and Cross Chain Assets](/builders/xcm/xc20){target=_blank} overview.
+Initially, Moonbeam will only support remote transfers. All cross-chain assets on Moonbeam will be known as _xc + TokenName_. For example, Polkadot's DOT representation on Moonbeam is known as _xcDOT_ and Kusama's KSM representation on Moonriver is _xcKSM_. You can read more about the XC-20 standard in the [XC-20s and Cross Chain Assets](/builders/xcm/xc20){target=_blank} overview.
 
 **Developers must understand that sending incorrect XCM messages can result in the loss of funds.** Consequently, it is essential to test XCM features on a TestNet before moving to a production environment.
 
@@ -61,7 +61,7 @@ A channel for XCMs between the relay chain and parachain is automatically opened
     * Maximum number of messages in the destination queue
     * Maximum size of the messages to be sent
 
-The transaction fees are paid in the cross-chain (xc) representation of the relay chain asset (_xc-RelayChainAsset_). For example, for Polkadot/Moonbeam, the transaction fees are paid in _xc-DOT_. Similarly for Kusama/Moonriver, the transaction fees are paid in _xc-KSM_. Therefore, the account paying for the fees must have enough _xc-RelayChainAsset_. This might be tackled on Moonbeam/Moonriver by having fees from incoming XCM messages, which are paid in the origin chain asset, sent to the treasury, and using the treasury account to pay for the channel registration extrinsic.
+The transaction fees are paid in the cross-chain (xc) representation of the relay chain asset (_xcRelayChainAsset_). For example, for Polkadot/Moonbeam, the transaction fees are paid in _xcDOT_. Similarly for Kusama/Moonriver, the transaction fees are paid in _xcKSM_. Therefore, the account paying for the fees must have enough _xcRelayChainAsset_. This might be tackled on Moonbeam/Moonriver by having fees from incoming XCM messages, which are paid in the origin chain asset, sent to the treasury, and using the treasury account to pay for the channel registration extrinsic.
 
 Even though parachain A has expressed its intentions of opening an XCM channel with parachain B, the latter has not signaled to the relay chain its intentions to receive messages from parachain A. Therefore, to have an established channel, parachain B must also send an extrinsic (which is also an XCM) to the relay chain. The accepting channel extrinsic is similar to the previous one. However, the encoded call data only includes the new method (accept channel) and the parachain ID of the sender (parachain A in this example). Once both parachains have agreed, the channel is opened within the next epoch change.
 
@@ -114,7 +114,7 @@ Alice (Polkadot) wants to transfer a certain amount of DOTs from Polkadot to her
 
 Consequently, the XCM message execution on Polkadot will transfer the amount of DOTs to Moonbeam's Sovereign account on Polkadot. Once the assets are deposited, the second part of the message is sent to Moonbeam.
 
-Moonbeam will locally execute the action the XCM message is programmed to do. In this case, it is to mint and transfer the same amount of _xc-DOTs_ (cross-chain DOTs) to the account defined by Alice, which in this case is Alith. The fee to execute the XCM in the target parachain is paid in the asset being transferred (_xc-DOTs_ for this example).
+Moonbeam will locally execute the action the XCM message is programmed to do. In this case, it is to mint and transfer the same amount of _xcDOTs_ (cross-chain DOTs) to the account defined by Alice, which in this case is Alith. The fee to execute the XCM in the target parachain is paid in the asset being transferred (_xcDOTs_ for this example).
 
 ![Transfers from the Relay Chain to Moonbeam](/images/builders/xcm/overview/overview-5.png)
 
@@ -122,13 +122,13 @@ Note the following:
 
 - Alice and Alith accounts can be different. For example, Polkadot's accounts are SR25519 (or ED25519), while Moonbeam's are ECDSA (Ethereum styled) accounts. They can also have different owners
 - There is a certain degree of trust, where one chain relies on the other to execute its part of the XCM message. This is programmed at a runtime level, so it can be easily verified
-- For this example, cross-chain DOTs (_xc-DOTS_) are a wrapped representation of the original DOTs being held in Moonbeam's Sovereign account on Polkadot. _xc-DOTs_ can be transferred within Moonbeam at any time, and they can be redeemed for DOTs on a 1:1 basis as well
+- For this example, cross-chain DOTs (_xcDOTS_) are a wrapped representation of the original DOTs being held in Moonbeam's Sovereign account on Polkadot. _xcDOTs_ can be transferred within Moonbeam at any time, and they can be redeemed for DOTs on a 1:1 basis as well
 
-Alith deposited her _xc-DOTs_ in a liquidity pool. Next, Charleth acquires some _xc-DOTs_ by swapping against that liquidity pool, and he wants to transfer some _xc-DOTs_ to Charley's Polkadot account. Therefore, he initiates an XCM that expresses his intentions.
+Alith deposited her _xcDOTs_ in a liquidity pool. Next, Charleth acquires some _xcDOTs_ by swapping against that liquidity pool, and he wants to transfer some _xcDOTs_ to Charley's Polkadot account. Therefore, he initiates an XCM that expresses his intentions.
 
-Consequently, the XCM message execution on Moonbeam will burn the number of _xc-DOTs_. Once the assets are burned, the second part of the message is sent to Polkadot.
+Consequently, the XCM message execution on Moonbeam will burn the number of _xcDOTs_. Once the assets are burned, the second part of the message is sent to Polkadot.
 
-Polkadot will execute the action locally the XCM message is programmed to do locally. In this case, it is to transfer the same amount of _xc-DOTs_ burned from the Moonbeam Sovereign account to the account defined by Charleth, which in this case is Charley.
+Polkadot will execute the action locally the XCM message is programmed to do locally. In this case, it is to transfer the same amount of _xcDOTs_ burned from the Moonbeam Sovereign account to the account defined by Charleth, which in this case is Charley.
 
 ![Transfers Back from Moonbeam to the Relay Chain](/images/builders/xcm/overview/overview-6.png)
 
@@ -140,8 +140,8 @@ The first requirement is that a channel between the parachains must exist, and t
 
 Then, when Alith (Moonbeam) transfers a certain amount of GLMRs from Moonbeam to another account (Alice) in a target parachain, tokens are sent to a Sovereign Account owned by that target parachain on Moonbeam.
 
-As the XCM message is executed in the target parachain, it is expected that this will mint and transfer the same amount of _xc-GLMRs_ (cross-chain GLMRs) to the account defined by Alith, which in this case is Alice. The fee to execute the XCM in the target parachain is paid in the transferred asset (_xc-GLMRs_ for this example).
+As the XCM message is executed in the target parachain, it is expected that this will mint and transfer the same amount of _xcGLMRs_ (cross-chain GLMRs) to the account defined by Alith, which in this case is Alice. The fee to execute the XCM in the target parachain is paid in the transferred asset (_xcGLMRs_ for this example).
 
 ![Transfers from Moonbeam to another Parachain](/images/builders/xcm/overview/overview-7.png)
 
-The process is similar for _xc-GLMRs_ to move back to Moonbeam as explained in the previous section. First, the XCM message execution burns the number of _xc-GLMRs_ returned to Moonbeam. Once burned, the remnant part of the message is sent to Moonbeam via the relay chain. Moonbeam will locally execute the XCM message's, and transfer GLMRs (the same amount of burned _xc-GLMRs_) from the target parachain Sovereign account to the specified address.
+The process is similar for _xcGLMRs_ to move back to Moonbeam as explained in the previous section. First, the XCM message execution burns the number of _xcGLMRs_ returned to Moonbeam. Once burned, the remnant part of the message is sent to Moonbeam via the relay chain. Moonbeam will locally execute the XCM message's, and transfer GLMRs (the same amount of burned _xcGLMRs_) from the target parachain Sovereign account to the specified address.

--- a/builders/xcm/overview.md
+++ b/builders/xcm/overview.md
@@ -7,7 +7,7 @@ description: An overview of how cross-consensus messaging (XCM) works, and how d
 
 ![XCM Overview Banner](/images/builders/xcm/overview/overview-banner.png)
 
-## Introduction
+## Introduction {: #introduction }
 
 [Polkadot's architecture](https://wiki.polkadot.network/docs/learn-architecture){target=_blank} allows parachains to natively interoperate with each other, enabling cross-blockchain transfers of any type of data or asset.
 
@@ -17,7 +17,7 @@ This page is an brief introduction and overview of XCM and other related element
 
 --8<-- 'text/xcm/general-xcm-definitions.md'
 
-## XCM Transport Protocols
+## XCM Transport Protocols {: #xcm-transport-protocols }
 
 Polkadot implements two cross-consensus or transport protocols for acting on XCM messages between its constituent parachains, Moonbeam being one of them:
 
@@ -42,11 +42,11 @@ Furthermore, the two most common use-cases for XCM messages, at least in the ear
 
 A much more detailed article about XCM can be found in the [Polkadot Wiki](https://wiki.polkadot.network/docs/learn-crosschain){target=_blank}.
 
-Initially, Moonbeam will only support remote transfers. All cross-chain assets on Moonbeam will be known as _xc + TokenName_. For example, Kusama's KSM representation on Moonriver will be known as _xcKSM_. You can read more about the XC-20 standard [here](/builders/xcm/xc20){target=_blank}.
+Initially, Moonbeam will only support remote transfers. All cross-chain assets on Moonbeam will be known as _xc- + TokenName_. For example, Polkadot's DOT representation on Moonbeam is known as _xc-DOT_ and Kusama's KSM representation on Moonriver is _xc-KSM_. You can read more about the XC-20 standard in the [XC-20s and Cross Chain Assets](/builders/xcm/xc20){target=_blank} overview.
 
 **Developers must understand that sending incorrect XCM messages can result in the loss of funds.** Consequently, it is essential to test XCM features on a TestNet before moving to a production environment.
 
-## Channel Registration
+## Channel Registration {: #channel-registration }
 
 Before two chains can start communicating, a messaging channel must be opened. Channels are unidirectional, meaning that a channel from chain A to chain B will only pass messages from A to B. Consequently, asset transfers will be possible only from chains A to B. Therefore, two channels must be opened to send messages (or transfer assets) back and forth.
 
@@ -61,7 +61,7 @@ A channel for XCMs between the relay chain and parachain is automatically opened
     * Maximum number of messages in the destination queue
     * Maximum size of the messages to be sent
 
-The transaction fees are paid in the cross-chain (xc) representation of the relay chain asset (_xcRelayChainAsset_). For example, for Kusama/Moonriver, the transaction fees would be paid in _xcKSM_. Therefore, the account paying for the fees must have enough _xcRelayChainAsset_. This might be tackled on Moonbeam/Moonriver by having fees from incoming XCM messages, which are paid in the origin chain asset, sent to the treasury, and using the treasury account to pay for the channel registration extrinsic.
+The transaction fees are paid in the cross-chain (xc) representation of the relay chain asset (_xc-RelayChainAsset_). For example, for Polkadot/Moonbeam, the transaction fees are paid in _xc-DOT_. Similarly for Kusama/Moonriver, the transaction fees are paid in _xc-KSM_. Therefore, the account paying for the fees must have enough _xc-RelayChainAsset_. This might be tackled on Moonbeam/Moonriver by having fees from incoming XCM messages, which are paid in the origin chain asset, sent to the treasury, and using the treasury account to pay for the channel registration extrinsic.
 
 Even though parachain A has expressed its intentions of opening an XCM channel with parachain B, the latter has not signaled to the relay chain its intentions to receive messages from parachain A. Therefore, to have an established channel, parachain B must also send an extrinsic (which is also an XCM) to the relay chain. The accepting channel extrinsic is similar to the previous one. However, the encoded call data only includes the new method (accept channel) and the parachain ID of the sender (parachain A in this example). Once both parachains have agreed, the channel is opened within the next epoch change.
 
@@ -71,7 +71,7 @@ All the actions mentioned above can be executed via SUDO (if available), or thro
 
 Once the channel is established, assets need to be registered before being transferred through XCMs, either by being baked into the runtime as a constant, or through a pallet. The asset registration process for Moonbeam is explained in the next section.
 
-## XCM Asset Registration
+## XCM Asset Registration {: #xcm-asset-registration }
 
 Once a channel is established between parachains (or relay chain-parachain), asset registration can occur. 
 
@@ -90,7 +90,7 @@ Once the channel has been successfully established, the XCM asset registered in 
 
 All the actions mentioned above can be executed via SUDO (if available), or through Democracy (technical committee or referenda).
 
-## Moonbeam and XCM
+## Moonbeam and XCM {: #moonbeam-and-xcm }
 
 As Moonbeam is a parachain within the Polkadot ecosystems, one of the most direct implementations of XCM is to enable asset transfer from Polkadot and other parachains from/to Moonbeam. This will allow users to bring their tokens to Moonbeam and all its dApps.
 
@@ -104,7 +104,7 @@ Depending on the target blockchain, asset transfers can be done via teleporting 
 
 The following sections provide a high-level overview of the two initial use cases for XCM on Moonbeam: asset transfers from/to Polkadot (via VMP) and asset transfers from/to other parachains (via XCMP). This page will be expanded as more interoperability features become available, such as movements of ERC-20 tokens from Moonbeam to other parachains, or movement of other assets to Moonbeam as ERC-20 representations.
 
-### Moonbeam & Polkadot
+### Moonbeam & Polkadot {: #moonbeam-polkadot }
 
 As Moonbeam is a parachain within the Polkadot ecosystem, XCM + VMP allows DOT transfers from/to Polkadot/Moonbeam. This section goes through a high-level overview of all the actions involved during the execution of such XCM messages.
 
@@ -114,7 +114,7 @@ Alice (Polkadot) wants to transfer a certain amount of DOTs from Polkadot to her
 
 Consequently, the XCM message execution on Polkadot will transfer the amount of DOTs to Moonbeam's Sovereign account on Polkadot. Once the assets are deposited, the second part of the message is sent to Moonbeam.
 
-Moonbeam will locally execute the action the XCM message is programmed to do. In this case, it is to mint and transfer the same amount of _xcDOTs_ (cross-chain DOTs) to the account defined by Alice, which in this case is Alith. The fee to execute the XCM in the target parachain is paid in the asset being transferred (_xcDOTs_ for this example).
+Moonbeam will locally execute the action the XCM message is programmed to do. In this case, it is to mint and transfer the same amount of _xc-DOTs_ (cross-chain DOTs) to the account defined by Alice, which in this case is Alith. The fee to execute the XCM in the target parachain is paid in the asset being transferred (_xc-DOTs_ for this example).
 
 ![Transfers from the Relay Chain to Moonbeam](/images/builders/xcm/overview/overview-5.png)
 
@@ -122,17 +122,17 @@ Note the following:
 
 - Alice and Alith accounts can be different. For example, Polkadot's accounts are SR25519 (or ED25519), while Moonbeam's are ECDSA (Ethereum styled) accounts. They can also have different owners
 - There is a certain degree of trust, where one chain relies on the other to execute its part of the XCM message. This is programmed at a runtime level, so it can be easily verified
-- For this example, cross-chain DOTs (_xcDOTS_) are a wrapped representation of the original DOTs being held in Moonbeam's Sovereign account on Polkadot. _xcDOTs_ can be transferred within Moonbeam at any time, and they can be redeemed for DOTs on a 1:1 basis as well
+- For this example, cross-chain DOTs (_xc-DOTS_) are a wrapped representation of the original DOTs being held in Moonbeam's Sovereign account on Polkadot. _xc-DOTs_ can be transferred within Moonbeam at any time, and they can be redeemed for DOTs on a 1:1 basis as well
 
-Alith deposited her _xcDOTs_ in a liquidity pool. Next, Charleth acquires some _xcDOTs_ by swapping against that liquidity pool, and he wants to transfer some _xcDOTs_ to Charley's Polkadot account. Therefore, he initiates an XCM that expresses his intentions.
+Alith deposited her _xc-DOTs_ in a liquidity pool. Next, Charleth acquires some _xc-DOTs_ by swapping against that liquidity pool, and he wants to transfer some _xc-DOTs_ to Charley's Polkadot account. Therefore, he initiates an XCM that expresses his intentions.
 
-Consequently, the XCM message execution on Moonbeam will burn the number of _xcDOTs_. Once the assets are burned, the second part of the message is sent to Polkadot.
+Consequently, the XCM message execution on Moonbeam will burn the number of _xc-DOTs_. Once the assets are burned, the second part of the message is sent to Polkadot.
 
-Polkadot will execute the action locally the XCM message is programmed to do locally. In this case, it is to transfer the same amount of _xcDOTs_ burned from the Moonbeam Sovereign account to the account defined by Charleth, which in this case is Charley.
+Polkadot will execute the action locally the XCM message is programmed to do locally. In this case, it is to transfer the same amount of _xc-DOTs_ burned from the Moonbeam Sovereign account to the account defined by Charleth, which in this case is Charley.
 
 ![Transfers Back from Moonbeam to the Relay Chain](/images/builders/xcm/overview/overview-6.png)
 
-### Moonbeam & Other Parachains
+### Moonbeam & Other Parachains {: #moonbeam-other-parachains }
 
 As Moonbeam is a parachain within the Polkadot ecosystem, XCM + XCMP allows asset transfers from/to Moonbeam and other parachains. This section goes through a high-level overview of the main differences compared to XCMs from/to Polkadot/Moonbeam. 
 
@@ -140,8 +140,8 @@ The first requirement is that a channel between the parachains must exist, and t
 
 Then, when Alith (Moonbeam) transfers a certain amount of GLMRs from Moonbeam to another account (Alice) in a target parachain, tokens are sent to a Sovereign Account owned by that target parachain on Moonbeam.
 
-As the XCM message is executed in the target parachain, it is expected that this will mint and transfer the same amount of _xcGLMRs_ (cross-chain GLMRs) to the account defined by Alith, which in this case is Alice. The fee to execute the XCM in the target parachain is paid in the transferred asset (_xcGLMRs_ for this example).
+As the XCM message is executed in the target parachain, it is expected that this will mint and transfer the same amount of _xc-GLMRs_ (cross-chain GLMRs) to the account defined by Alith, which in this case is Alice. The fee to execute the XCM in the target parachain is paid in the transferred asset (_xc-GLMRs_ for this example).
 
 ![Transfers from Moonbeam to another Parachain](/images/builders/xcm/overview/overview-7.png)
 
-The process is similar for _xcGLMRs_ to move back to Moonbeam as explained in the previous section. First, the XCM message execution burns the number of _xcGLMRs_ returned to Moonbeam. Once burned, the remnant part of the message is sent to Moonbeam via the relay chain. Moonbeam will locally execute the XCM message's, and transfer GLMRs (the same amount of burned _xcGLMRs_) from the target parachain Sovereign account to the specified address.
+The process is similar for _xc-GLMRs_ to move back to Moonbeam as explained in the previous section. First, the XCM message execution burns the number of _xc-GLMRs_ returned to Moonbeam. Once burned, the remnant part of the message is sent to Moonbeam via the relay chain. Moonbeam will locally execute the XCM message's, and transfer GLMRs (the same amount of burned _xc-GLMRs_) from the target parachain Sovereign account to the specified address.

--- a/builders/xcm/xc20/overview.md
+++ b/builders/xcm/xc20/overview.md
@@ -17,7 +17,7 @@ XC-20s are a unique asset class on Moonbeam. It combines the power of Substrate 
 
 ![Moonbeam XC-20 XCM Integration With Polkadot](/images/builders/xcm/overview/overview-4.png)
 
-XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Polkadot's DOT representation on Moonbeam is known as _xcDOT_ and Kusama's KSM representation on Moonriver is _xcKSM_. Please note that XC-20 precompiles do not support cross-chain transfers, and this is intentionally done to stay as close as possible to the standard ERC-20 interface.
+XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Polkadot's DOT representation on Moonbeam is known as _xcDOT_ and Kusama's KSM representation on Moonriver is _xcKSM_. Please note that XC-20 precompiles do not support cross-chain transfers within the contract itself, and this is intentionally done to stay as close as possible to the standard ERC-20 interface. Cross-chain transfer of XC-20s are done using the [X-Tokens pallet](/builders/xcm/xc20/xtokens/).
 
 XC-20s need to be registered and linked to another asset in the ecosystem before being used. This is done through a whitelisting process via a democracy proposal. If you are interested in testing XCM features in our TestNet, please contact us through our [Discord Server](https://discord.gg/PfpUATX){target=_blank}. For more information on XCM, you can check out the [XCM Overview](/builders/xcm/overview/){target=_blank} page of our documentation.
 

--- a/builders/xcm/xc20/overview.md
+++ b/builders/xcm/xc20/overview.md
@@ -9,21 +9,28 @@ description:  Learn how to access and interact with an ERC-20 interface for cros
 
 ## Introduction {: #introduction } 
 
-The [Cross-Consensus Message (XCM)](https://wiki.polkadot.network/docs/learn-crosschain) format defines how messages can be sent between interoperable blockchains. This format opens the door to transfer messages and assets (Substrate assets) between Moonbeam/Moonriver and the relay chain or other parachains in the Polkadot/Kusama ecosystems. 
+The [Cross-Consensus Message (XCM)](https://wiki.polkadot.network/docs/learn-crosschain){target=_blank} format defines how messages can be sent between interoperable blockchains. This format opens the door to transfer messages and assets (Substrate assets) between Moonbeam/Moonriver and the relay chain or other parachains in the Polkadot/Kusama ecosystems. 
 
 Substrate assets are natively interoperable. However, developers need to tap into the Substrate API to interact with them, making the developer experience unideal, especially for those from the Ethereum world. Consequently, to help developers tap into the native interoperability that Polkadot/Kusama offers, Moonbeam introduced the concept of XC-20s.
 
-XC-20s are a unique asset class on Moonbeam. It combines the power of Substrate assets (native interoperability) but allows users and developers to interact with them through a familiar [ERC-20 interface](https://github.com/PureStake/moonbeam/blob/master/precompiles/assets-erc20/ERC20.sol) via a precompile contract (Ethereum API). Moreover, developers can integrate XC-20s with regular Ethereum development frameworks or dApps. 
+XC-20s are a unique asset class on Moonbeam. It combines the power of Substrate assets (native interoperability) but allows users and developers to interact with them through a familiar [ERC-20 interface](https://github.com/PureStake/moonbeam/blob/master/precompiles/assets-erc20/ERC20.sol){target=_blank} via a precompile contract (Ethereum API). Moreover, developers can integrate XC-20s with regular Ethereum development frameworks or dApps. 
 
 ![Moonbeam XC-20 XCM Integration With Polkadot](/images/builders/xcm/overview/overview-4.png)
 
-XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Kusama's KSM representation on Moonriver will be known as _xcKSM_. Please note that XC-20 precompiles do not support cross-chain transfers, and this is intentionally done to stay as close as possible to the standard ERC-20 interface.
+XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Polkadot's DOT representation on Moonbeam is known as _xc-DOT_ and Kusama's KSM representation on Moonriver is _xc-KSM_. Please note that XC-20 precompiles do not support cross-chain transfers, and this is intentionally done to stay as close as possible to the standard ERC-20 interface.
 
-XC-20s need to be registered and linked to another asset in the ecosystem before being used. This is done through a whitelisting process via a democracy proposal. If you are interested in testing XCM features in our TestNet, please contact us through our [Discord Server](https://discord.gg/PfpUATX). For more information on XCM, you can check out the [XCM Overview](/builders/xcm/overview/) page of our documentation.
+XC-20s need to be registered and linked to another asset in the ecosystem before being used. This is done through a whitelisting process via a democracy proposal. If you are interested in testing XCM features in our TestNet, please contact us through our [Discord Server](https://discord.gg/PfpUATX){target=_blank}. For more information on XCM, you can check out the [XCM Overview](/builders/xcm/overview/){target=_blank} page of our documentation.
 
 ## Current XC-20 Assets {: #current-xc20-assets}
 
 The current list of available XC-20 assets per network is the following:
+
+=== "Moonbeam"
+    |  Origin  | Symbol |                                                            XC-20 Address                                                            |
+    |:--------:|:------:|:-----------------------------------------------------------------------------------------------------------------------------------:|
+    | Polkadot | xc-DOT | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
+
+     _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/assets){target=_blank}_
 
 === "Moonriver"
     |  Origin   | Symbol  |                                                                 XC-20 Address                                                                 |
@@ -37,7 +44,7 @@ The current list of available XC-20 assets per network is the following:
     | Statemine | xc-RMRK | [0xffffffFF893264794d9d57E1E0E21E0042aF5A0A](https://moonriver.moonscan.io/address/0xffffffFF893264794d9d57E1E0E21E0042aF5A0A){target=_blank} |
     | Statemine | xc-USDT | [0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d](https://moonriver.moonscan.io/address/0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d){target=_blank} |
 
-     _*You can check each Asset ID [here](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/assets){target=_blank}_
+     _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/assets){target=_blank}_
 
 === "Moonbase Alpha"
     |         Origin          |  Symbol  |                                                                XC-20 Address                                                                 |
@@ -57,7 +64,7 @@ The current list of available XC-20 assets per network is the following:
     |   Statemine Alphanet    | xc-MRMRK | [0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d](https://moonbase.moonscan.io/address/0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d){target=_blank} |
     
 
-     _*You can check each Asset ID [here](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}_
+     _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}_
 
 This guide will show you how to retrieve the available XC-20s and calculate their precompile addresses for the Moonbase Alpha TestNet using Polkadot.js Apps. In addition, you will learn how to interact with an XC-20 precompile using Remix.
 
@@ -65,7 +72,7 @@ This guide will show you how to retrieve the available XC-20s and calculate thei
 
 Although XC-20s and ERC-20s are very similar, some distinct differences are to be aware of. 
 
-First and foremost, XC-20s are Substrate-based assets, and as such, they are also subject to be directly impacted by Substrate features such as governance. In addition, XC-20s transactions done via the Substrate API won't be visible from EVM-based block explorers such as [Moonscan](https://moonscan.io). Only transactions done via the Ethereum API are visible through such explorers.
+First and foremost, XC-20s are Substrate-based assets, and as such, they are also subject to be directly impacted by Substrate features such as governance. In addition, XC-20s transactions done via the Substrate API won't be visible from EVM-based block explorers such as [Moonscan](https://moonscan.io){target=_blank}. Only transactions done via the Ethereum API are visible through such explorers.
 
 Nevertheless, XC-20s can be interacted with through an ERC-20 interface, so they have the additional benefit of being accessible from both the Substrate and Ethereum APIs. This ultimately provides greater flexibility for developers when working with these types of assets and allows seamless integrations with EVM-based smart contracts such as DEXs, lending platforms, among others.
 
@@ -126,15 +133,15 @@ The [ERC20.sol](https://github.com/PureStake/moonbeam/blob/master/precompiles/as
 
 To approve a spend or transfer XC-20s via the XC-20 precompile, you will need:
 
-- [MetaMask installed and connected to the Moonbase Alpha](/tokens/connect/metamask/) TestNet
+- [MetaMask installed and connected to the Moonbase Alpha](/tokens/connect/metamask/){target=_blank} TestNet
 - Create or have two accounts on Moonbase Alpha
-- At least one of the accounts will need to be funded with `DEV` tokens. You can obtain tokens for testing purposes from [Mission Control](/builders/get-started/networks/moonbase/#get-tokens/)
+- At least one of the accounts will need to be funded with `DEV` tokens. You can obtain tokens for testing purposes from [Mission Control](/builders/get-started/networks/moonbase/#get-tokens/){target=_blank}
 
 ## Interact with the Precompile Using Remix {: #interact-with-the-precompile-using-remix } 
 
-You can interact with the XC-20 precompile using [Remix](https://remix.ethereum.org/). First, you will need to add the ERC-20 interface to Remix:
+You can interact with the XC-20 precompile using [Remix](https://remix.ethereum.org/){target=_blank}. First, you will need to add the ERC-20 interface to Remix:
 
-1. Get a copy of [ERC20.sol](https://github.com/PureStake/moonbeam/blob/master/precompiles/assets-erc20/ERC20.sol) 
+1. Get a copy of [ERC20.sol](https://github.com/PureStake/moonbeam/blob/master/precompiles/assets-erc20/ERC20.sol){target=_blank} 
 2. Paste the file contents into a Remix file named **IERC20.sol**
 
 ![Load the interface in Remix](/images/builders/xcm/xc20/overview/xc20-3.png)
@@ -169,4 +176,4 @@ The **IERC20** precompile for the XC-20 will appear in the list of **Deployed Co
 
 ![Interact with the precompile functions](/images/builders/xcm/xc20/overview/xc20-6.png)
 
-To learn how to interact with each of the functions, you can check out the [ERC-20 Precompile](/builders/build/canonical-contracts/precompiles/erc20/) guide and modify it for interacting with the XC-20 precompile.
+To learn how to interact with each of the functions, you can check out the [ERC-20 Precompile](/builders/build/canonical-contracts/precompiles/erc20/){target=_blank} guide and modify it for interacting with the XC-20 precompile.

--- a/builders/xcm/xc20/overview.md
+++ b/builders/xcm/xc20/overview.md
@@ -17,7 +17,7 @@ XC-20s are a unique asset class on Moonbeam. It combines the power of Substrate 
 
 ![Moonbeam XC-20 XCM Integration With Polkadot](/images/builders/xcm/overview/overview-4.png)
 
-XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Polkadot's DOT representation on Moonbeam is known as _xc-DOT_ and Kusama's KSM representation on Moonriver is _xc-KSM_. Please note that XC-20 precompiles do not support cross-chain transfers, and this is intentionally done to stay as close as possible to the standard ERC-20 interface.
+XC-20 assets will be differentiated by having `xc` prepended to their name. For example, Polkadot's DOT representation on Moonbeam is known as _xcDOT_ and Kusama's KSM representation on Moonriver is _xcKSM_. Please note that XC-20 precompiles do not support cross-chain transfers, and this is intentionally done to stay as close as possible to the standard ERC-20 interface.
 
 XC-20s need to be registered and linked to another asset in the ecosystem before being used. This is done through a whitelisting process via a democracy proposal. If you are interested in testing XCM features in our TestNet, please contact us through our [Discord Server](https://discord.gg/PfpUATX){target=_blank}. For more information on XCM, you can check out the [XCM Overview](/builders/xcm/overview/){target=_blank} page of our documentation.
 
@@ -28,40 +28,40 @@ The current list of available XC-20 assets per network is the following:
 === "Moonbeam"
     |  Origin  | Symbol |                                                            XC-20 Address                                                            |
     |:--------:|:------:|:-----------------------------------------------------------------------------------------------------------------------------------:|
-    | Polkadot | xc-DOT | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
+    | Polkadot | xcDOT  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
 
      _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbeam.network#/assets){target=_blank}_
 
 === "Moonriver"
-    |  Origin   | Symbol  |                                                                 XC-20 Address                                                                 |
-    |:---------:|:-------:|:---------------------------------------------------------------------------------------------------------------------------------------------:|
-    |  Kusama   | xc-KSM  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonriver.moonscan.io/address/0xffffffff1fcacbd218edc0eba20fc2308c778080){target=_blank} |
-    |  Bifrost  | xc-BNC  | [0xFFfFFfFFF075423be54811EcB478e911F22dDe7D](https://moonriver.moonscan.io/address/0xFFfFFfFFF075423be54811EcB478e911F22dDe7D){target=_blank} |
-    |  Karura   | xc-KAR  | [0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5](https://moonriver.moonscan.io/address/0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5){target=_blank} |
-    |  Karura   | xc-aUSD | [0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228](https://moonriver.moonscan.io/address/0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228){target=_blank} |
-    | Kintsugi  | xc-KINT | [0xfffFFFFF83F4f317d3cbF6EC6250AeC3697b3fF2](https://moonriver.moonscan.io/address/0xfffFFFFF83F4f317d3cbF6EC6250AeC3697b3fF2){target=_blank} |
-    | Kintsugi  | xc-kBTC | [0xFFFfFfFfF6E528AD57184579beeE00c5d5e646F0](https://moonriver.moonscan.io/address/0xFFFfFfFfF6E528AD57184579beeE00c5d5e646F0){target=_blank} |
-    | Statemine | xc-RMRK | [0xffffffFF893264794d9d57E1E0E21E0042aF5A0A](https://moonriver.moonscan.io/address/0xffffffFF893264794d9d57E1E0E21E0042aF5A0A){target=_blank} |
-    | Statemine | xc-USDT | [0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d](https://moonriver.moonscan.io/address/0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d){target=_blank} |
+    |  Origin   | Symbol |                                                                 XC-20 Address                                                                 |
+    |:---------:|:------:|:---------------------------------------------------------------------------------------------------------------------------------------------:|
+    |  Kusama   | xcKSM  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonriver.moonscan.io/address/0xffffffff1fcacbd218edc0eba20fc2308c778080){target=_blank} |
+    |  Bifrost  | xcBNC  | [0xFFfFFfFFF075423be54811EcB478e911F22dDe7D](https://moonriver.moonscan.io/address/0xFFfFFfFFF075423be54811EcB478e911F22dDe7D){target=_blank} |
+    |  Karura   | xcKAR  | [0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5](https://moonriver.moonscan.io/address/0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5){target=_blank} |
+    |  Karura   | xcaUSD | [0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228](https://moonriver.moonscan.io/address/0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228){target=_blank} |
+    | Kintsugi  | xcKINT | [0xfffFFFFF83F4f317d3cbF6EC6250AeC3697b3fF2](https://moonriver.moonscan.io/address/0xfffFFFFF83F4f317d3cbF6EC6250AeC3697b3fF2){target=_blank} |
+    | Kintsugi  | xckBTC | [0xFFFfFfFfF6E528AD57184579beeE00c5d5e646F0](https://moonriver.moonscan.io/address/0xFFFfFfFfF6E528AD57184579beeE00c5d5e646F0){target=_blank} |
+    | Statemine | xcRMRK | [0xffffffFF893264794d9d57E1E0E21E0042aF5A0A](https://moonriver.moonscan.io/address/0xffffffFF893264794d9d57E1E0E21E0042aF5A0A){target=_blank} |
+    | Statemine | xcUSDT | [0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d](https://moonriver.moonscan.io/address/0xFFFFFFfFea09FB06d082fd1275CD48b191cbCD1d){target=_blank} |
 
      _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/assets){target=_blank}_
 
 === "Moonbase Alpha"
-    |         Origin          |  Symbol  |                                                                XC-20 Address                                                                 |
-    |:-----------------------:|:--------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
-    |  Relay Chain Alphanet   | xc-UNIT  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonbase.moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
-    |    Basilisk Alphanet    |  xc-BSX  | [0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA](https://moonbase.moonscan.io/address/0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA){target=_blank} |
-    |    Bifrost Alphanet     |  xc-BNC  | [0xFffFFFfF1FAE104Dc4C134306bCA8e2E1990aCfd](https://moonbase.moonscan.io/address/0xFffFFFfF1FAE104Dc4C134306bCA8e2E1990aCfd){target=_blank} |
-    |    Calamari Alphanet    |  xc-KMA  | [0xFFffFffFA083189f870640b141ae1E882c2b5bad](https://moonbase.moonscan.io/address/0xFFffFffFA083189f870640b141ae1E882c2b5bad){target=_blank} |
-    |  Crust/Shadow Alphanet  |  xc-CSM  | [0xffFfFFFf519811215E05eFA24830Eebe9c43aCD7](https://moonbase.moonscan.io/address/0xffFfFFFf519811215E05eFA24830Eebe9c43aCD7){target=_blank} |
-    |     Karura Alphanet     |  xc-KAR  | [0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5](https://moonbase.moonscan.io/address/0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5){target=_blank} |
-    |     Karura Alphanet     | xc-kUSD  | [0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228](https://moonbase.moonscan.io/address/0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228){target=_blank} |
-    |     Khala Alphanet      |  xc-PHA  | [0xffFfFFff8E6b63d9e447B6d4C45BDA8AF9dc9603](https://moonbase.moonscan.io/address/0xffFfFFff8E6b63d9e447B6d4C45BDA8AF9dc9603){target=_blank} |
-    |    Kintsugi Alphanet    | xc-KINT  | [0xFFFfffff27C019790DFBEE7cB70F5996671B2882](https://moonbase.moonscan.io/address/0xFFFfffff27C019790DFBEE7cB70F5996671B2882){target=_blank} |
-    |    Kintsugi Alphanet    | xc-kBTC  | [0xFffFfFff5C2Ec77818D0863088929C1106635d26](https://moonbase.moonscan.io/address/0xFffFfFff5C2Ec77818D0863088929C1106635d26){target=_blank} |
-    |    Litentry Alphanet    |  xc-LIT  | [0xfffFFfFF31103d490325BB0a8E40eF62e2F614C0](https://moonbase.moonscan.io/address/0xfffFFfFF31103d490325BB0a8E40eF62e2F614C0){target=_blank} |
-    | Parallel Heiko Alphanet |  xc-HKO  | [0xffffffFF394054BCDa1902B6A6436840435655a3](https://moonbase.moonscan.io/address/0xffffffFF394054BCDa1902B6A6436840435655a3){target=_blank} |
-    |   Statemine Alphanet    | xc-MRMRK | [0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d](https://moonbase.moonscan.io/address/0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d){target=_blank} |
+    |         Origin          | Symbol  |                                                                 XC20 Address                                                                 |
+    |:-----------------------:|:-------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
+    |  Relay Chain Alphanet   | xcUNIT  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonbase.moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
+    |    Basilisk Alphanet    |  xcBSX  | [0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA](https://moonbase.moonscan.io/address/0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA){target=_blank} |
+    |    Bifrost Alphanet     |  xcBNC  | [0xFffFFFfF1FAE104Dc4C134306bCA8e2E1990aCfd](https://moonbase.moonscan.io/address/0xFffFFFfF1FAE104Dc4C134306bCA8e2E1990aCfd){target=_blank} |
+    |    Calamari Alphanet    |  xcKMA  | [0xFFffFffFA083189f870640b141ae1E882c2b5bad](https://moonbase.moonscan.io/address/0xFFffFffFA083189f870640b141ae1E882c2b5bad){target=_blank} |
+    |  Crust/Shadow Alphanet  |  xcCSM  | [0xffFfFFFf519811215E05eFA24830Eebe9c43aCD7](https://moonbase.moonscan.io/address/0xffFfFFFf519811215E05eFA24830Eebe9c43aCD7){target=_blank} |
+    |     Karura Alphanet     |  xcKAR  | [0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5](https://moonbase.moonscan.io/address/0xFfFFFFfF08220AD2E6e157f26eD8bD22A336A0A5){target=_blank} |
+    |     Karura Alphanet     | xckUSD  | [0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228](https://moonbase.moonscan.io/address/0xFfFffFFfa1B026a00FbAA67c86D5d1d5BF8D8228){target=_blank} |
+    |     Khala Alphanet      |  xcPHA  | [0xffFfFFff8E6b63d9e447B6d4C45BDA8AF9dc9603](https://moonbase.moonscan.io/address/0xffFfFFff8E6b63d9e447B6d4C45BDA8AF9dc9603){target=_blank} |
+    |    Kintsugi Alphanet    | xcKINT  | [0xFFFfffff27C019790DFBEE7cB70F5996671B2882](https://moonbase.moonscan.io/address/0xFFFfffff27C019790DFBEE7cB70F5996671B2882){target=_blank} |
+    |    Kintsugi Alphanet    | xckBTC  | [0xFffFfFff5C2Ec77818D0863088929C1106635d26](https://moonbase.moonscan.io/address/0xFffFfFff5C2Ec77818D0863088929C1106635d26){target=_blank} |
+    |    Litentry Alphanet    |  xcLIT  | [0xfffFFfFF31103d490325BB0a8E40eF62e2F614C0](https://moonbase.moonscan.io/address/0xfffFFfFF31103d490325BB0a8E40eF62e2F614C0){target=_blank} |
+    | Parallel Heiko Alphanet |  xcHKO  | [0xffffffFF394054BCDa1902B6A6436840435655a3](https://moonbase.moonscan.io/address/0xffffffFF394054BCDa1902B6A6436840435655a3){target=_blank} |
+    |   Statemine Alphanet    | xcMRMRK | [0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d](https://moonbase.moonscan.io/address/0xFFffffFfd2aaD7f60626608Fa4a5d34768F7892d){target=_blank} |
     
 
      _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/assets){target=_blank}_

--- a/builders/xcm/xc20/overview.md
+++ b/builders/xcm/xc20/overview.md
@@ -47,7 +47,7 @@ The current list of available XC-20 assets per network is the following:
      _*You can check each Asset ID from the [Assets tab on Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonriver.moonbeam.network#/assets){target=_blank}_
 
 === "Moonbase Alpha"
-    |         Origin          | Symbol  |                                                                 XC20 Address                                                                 |
+    |         Origin          | Symbol  |                                                                XC-20 Address                                                                 |
     |:-----------------------:|:-------:|:--------------------------------------------------------------------------------------------------------------------------------------------:|
     |  Relay Chain Alphanet   | xcUNIT  | [0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080](https://moonbase.moonscan.io/address/0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080){target=_blank} |
     |    Basilisk Alphanet    |  xcBSX  | [0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA](https://moonbase.moonscan.io/address/0xFFfFfFfF4d0Ff56d0097BBd14920eaC488540BFA){target=_blank} |

--- a/builders/xcm/xc20/xtokens.md
+++ b/builders/xcm/xc20/xtokens.md
@@ -53,11 +53,11 @@ This guide covers the process of building an XCM message using the X-Tokens pall
 
 To be able to send the extrinsics in Polkadot.js Apps, you need to have an [account](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank} with [funds](https://docs.moonbeam.network/builders/get-started/networks/moonbase/#get-tokens){target=_blank}.
 
-In addition, you'll need to have some `xc-UNIT` tokens for this tutorial, which is the [XC-20](/builders/xcm/xc20/){target=_blank} representation of the Alphanet relay chain token `UNIT`. You can acquire some by swapping for `DEV` tokens (Moonbase Alpha's native token) on [Moonbeam-Swap](https://moonbeam-swap.netlify.app/#/swap){target=_blank}, a demo Uniswap-V2 clone on Moonbase Alpha.
+In addition, you'll need to have some `xcUNIT` tokens for this tutorial, which is the [XC-20](/builders/xcm/xc20/){target=_blank} representation of the Alphanet relay chain token `UNIT`. You can acquire some by swapping for `DEV` tokens (Moonbase Alpha's native token) on [Moonbeam-Swap](https://moonbeam-swap.netlify.app/#/swap){target=_blank}, a demo Uniswap-V2 clone on Moonbase Alpha.
 
-![Moonbeam Swap xc-UNITs](/images/builders/xcm/xc20/xtokens/xtokens-1.png)
+![Moonbeam Swap xcUNITs](/images/builders/xcm/xc20/xtokens/xtokens-1.png)
 
-To check your `xc-UNIT` balance, you can add the XC-20 to MetaMask with the following address:
+To check your `xcUNIT` balance, you can add the XC-20 to MetaMask with the following address:
 
 ```
 0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080
@@ -67,7 +67,7 @@ You can check the [XC-20](/builders/xcm/xc20/#calculate-xc20-address){target=_bl
 
 ### X-Tokens Transfer Function {: #xtokens-transfer-function}
 
-In this example, you'll build an XCM message to transfer `xc-UNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} through the `transfer` function of the X-Tokens pallet.
+In this example, you'll build an XCM message to transfer `xcUNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} through the `transfer` function of the X-Tokens pallet.
 
 If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the extrinsic page of [Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank} and set the following options:
 
@@ -100,7 +100,7 @@ Once the transaction is processed, the **TargetAccount** should have received th
 
 ### X-Tokens Transfer MultiAsset Function {: #xtokens-transfer-multiasset-function}
 
-In this example, you'll build an XCM message to transfer `xc-UNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} using the `transferMultiasset` function of the X-Tokens pallet.
+In this example, you'll build an XCM message to transfer `xcUNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} using the `transferMultiasset` function of the X-Tokens pallet.
 
 If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the extrinsic page of [Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank} and set the following options:
 
@@ -116,7 +116,7 @@ If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the
     | Interior  | Here  |
 
 5. Set the asset type as **Fungible**
-6. Set the number of tokens to send. For this example, you are sending 1 `xc-UNIT`, but you have to account for the 12 decimals
+6. Set the number of tokens to send. For this example, you are sending 1 `xcUNIT`, but you have to account for the 12 decimals
 7. To define the XCM destination multilocation, you have to target an account in the relay chain from Moonbase Alpha as the origin. Therefore, set the following parameters:
 
     | Parameter |     Value     |

--- a/builders/xcm/xc20/xtokens.md
+++ b/builders/xcm/xc20/xtokens.md
@@ -53,11 +53,11 @@ This guide covers the process of building an XCM message using the X-Tokens pall
 
 To be able to send the extrinsics in Polkadot.js Apps, you need to have an [account](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/accounts){target=_blank} with [funds](https://docs.moonbeam.network/builders/get-started/networks/moonbase/#get-tokens){target=_blank}.
 
-In addition, you'll need to have some `xcUNIT` tokens for this tutorial, which is the [XC-20](/builders/xcm/xc20/){target=_blank} representation of the Alphanet relay chain token `UNIT`. You can acquire some by swapping for `DEV` tokens (Moonbase Alpha's native token) on [Moonbeam-Swap](https://moonbeam-swap.netlify.app/#/swap){target=_blank}, a demo Uniswap-V2 clone on Moonbase Alpha.
+In addition, you'll need to have some `xc-UNIT` tokens for this tutorial, which is the [XC-20](/builders/xcm/xc20/){target=_blank} representation of the Alphanet relay chain token `UNIT`. You can acquire some by swapping for `DEV` tokens (Moonbase Alpha's native token) on [Moonbeam-Swap](https://moonbeam-swap.netlify.app/#/swap){target=_blank}, a demo Uniswap-V2 clone on Moonbase Alpha.
 
-![Moonbeam Swap xcUNITs](/images/builders/xcm/xc20/xtokens/xtokens-1.png)
+![Moonbeam Swap xc-UNITs](/images/builders/xcm/xc20/xtokens/xtokens-1.png)
 
-To check your `xcUNIT` balance, you can add the XC-20 to MetaMask with the following address:
+To check your `xc-UNIT` balance, you can add the XC-20 to MetaMask with the following address:
 
 ```
 0xFfFFfFff1FcaCBd218EDc0EbA20Fc2308C778080
@@ -67,7 +67,7 @@ You can check the [XC-20](/builders/xcm/xc20/#calculate-xc20-address){target=_bl
 
 ### X-Tokens Transfer Function {: #xtokens-transfer-function}
 
-In this example, you'll build an XCM message to transfer `xcUNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} through the `transfer function of the X-Tokens pallet.
+In this example, you'll build an XCM message to transfer `xc-UNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} through the `transfer` function of the X-Tokens pallet.
 
 If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the extrinsic page of [Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank} and set the following options:
 
@@ -100,7 +100,7 @@ Once the transaction is processed, the **TargetAccount** should have received th
 
 ### X-Tokens Transfer MultiAsset Function {: #xtokens-transfer-multiasset-function}
 
-In this example, you'll build an XCM message to transfer `xcUNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} using the `transferMultiasset` function of the X-Tokens pallet.
+In this example, you'll build an XCM message to transfer `xc-UNIT` from Moonbase Alpha back to its [relay chain](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Ffrag-moonbase-relay-rpc-ws.g.moonbase.moonbeam.network#/accounts){target=_blank} using the `transferMultiasset` function of the X-Tokens pallet.
 
 If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the extrinsic page of [Polkadot JS Apps](https://polkadot.js.org/apps/?rpc=wss%3A%2F%2Fwss.api.moonbase.moonbeam.network#/extrinsics){target=_blank} and set the following options:
 
@@ -116,7 +116,7 @@ If you've [checked the prerequisites](#xtokens-check-prerequisites), head to the
     | Interior  | Here  |
 
 5. Set the asset type as **Fungible**
-6. Set the number of tokens to send. For this example, you are sending 1 `xcUNIT`, but you have to account for the 12 decimals
+6. Set the number of tokens to send. For this example, you are sending 1 `xc-UNIT`, but you have to account for the 12 decimals
 7. To define the XCM destination multilocation, you have to target an account in the relay chain from Moonbase Alpha as the origin. Therefore, set the following parameters:
 
     | Parameter |     Value     |
@@ -166,7 +166,7 @@ The interface includes the following functions:
  - **transfer**(*address* currency_address, *uint256* amount, *Multilocation* *memory* destination, *uint64* weight) — function that represents the `transfer` method described in the previous example. However, instead of using the currency ID, you need to provide the [XC-20 address](/builders/xcm/xc20/#current-xc20-assets){target=_blank}. The multilocation is built in a particular way that is described in the following section
  - **transfer_multiasset**(*Multilocation* *memory* asset, *uint256* amount, *Multilocation* *memory* destination, *uint64* weight) — function that represents the `transferMultiasset` method described in the previous example. Both multilocations are built in a particular way that is described in the following section
 
-### Building the Precompile Multilocation
+### Building the Precompile Multilocation {: #building-the-precompile-multilocation }
 
 In the X-Tokens precompile interface, the `Multilocation` structure is defined as follows:
 


### PR DESCRIPTION
### Description

This PR adds xcDOT to the documentation site and also includes some minor fixes

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If images have been moved, I have created an additional PR in `moonbeam-docs-cn` to update images to their new paths
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a