### PR TITLE
Update state-cache-size value

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -16,7 +16,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \
@@ -36,7 +36,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \
@@ -54,7 +54,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \
@@ -74,7 +74,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \
@@ -93,7 +93,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \
@@ -113,7 +113,7 @@ purestake/moonbeam:v0.23.0 \
 --execution wasm \
 --wasm-execution compiled \
 --pruning archive \
---state-cache-size 1 \
+--state-cache-size 0 \
 -- \
 --execution wasm \
 --pruning 1000 \

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -79,7 +79,7 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -98,7 +98,7 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -117,7 +117,7 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -139,7 +139,7 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -159,7 +159,7 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -179,13 +179,16 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --wasm-execution compiled \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
     --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
+
+!!! note
+    For an overview of the above flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation.
 
 If you're using MacOS, there are adapted [code snippets](https://www.github.com/PureStake/moonbeam-docs-cn/blob/master/.snippets/text/full-node/macos-node.md){target=_blank} specific for MacOS which can be used instead.
 

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -30,7 +30,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--pruning`** - specifies the state pruning mode. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
     - **`archive`** - keeps the full state of all blocks
     - **`<number-of-blocks>`** - specifies a custom number of blocks to keep the state for
-- **`--state-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `1` to disable the cache and improve collator performance
+- **`--state-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `0` to disable the cache and improve collator performance
 - **`--db-cache`** - specifies the memory the database cache is limited to use. It is recommended to set it to 50% of the actual RAM your server has. For example, for 32 GB RAM, the value should be set to `16000`. The minimum value is `2000`, but it is below the recommended specs 
 - **`--base-path`** - specifies the base path where your chain data is stored
 - **`--chain`** - specifies the chain specification to use. It can be a predefined chainspec such as `{{ networks.moonbeam.chain_spec }}`, `{{ networks.moonriver.chain_spec }}`, or `{{ networks.moonbase.chain_spec }}`. Or it can be a path to a file with the chainspec (such as the one exported by the `build-spec` command)

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -211,7 +211,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
@@ -250,7 +250,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
@@ -289,7 +289,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \
@@ -331,7 +331,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
@@ -371,7 +371,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
@@ -411,7 +411,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --pruning=archive \
-         --state-cache-size 1 \
+         --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \
@@ -429,7 +429,7 @@ The next step is to create the systemd configuration file. If you are setting up
     ```
 
 !!! note
-    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`. This is **not** recommended for Collators. 
+    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`. This is **not** recommended for Collators. For an overview of the above flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation.
 
 !!! note
     You can specify a custom Prometheus port with the `--prometheus-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -91,7 +91,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonbeam.chain_spec }} \
     --name="Moonbeam-Tutorial" \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbeam-substitutes-tracing \
@@ -111,7 +111,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonriver.chain_spec }} \
     --name="Moonbeam-Tutorial" \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonriver-substitutes-tracing \
@@ -131,7 +131,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonbase.chain_spec }} \
     --name="Moonbeam-Tutorial" \
     --pruning archive \
-    --state-cache-size 1 \
+    --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \


### PR DESCRIPTION
### Description

Update the state-cache-size flag value as it should be set to `0` now instead of `1`. Also add links below the commands on the run a node pages that link back to the overview of the flags.

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
