### PR TITLE
adds endpoints for Moonbeam and Moonriver

### DIFF
--- a/.snippets/code/endpoints/moonbeam-https.md
+++ b/.snippets/code/endpoints/moonbeam-https.md
@@ -1,0 +1,9 @@
+=== "Dwellir"
+    ```
+    https://moonbeam-rpc.dwellir.com
+    ```
+
+=== "OnFinality"
+    ```
+    https://moonbeam.api.onfinality.io/public
+    ```

--- a/.snippets/code/endpoints/moonbeam-wss.md
+++ b/.snippets/code/endpoints/moonbeam-wss.md
@@ -1,0 +1,9 @@
+=== "Dwellir"
+    ```
+    wss://moonbeam-rpc.dwellir.com
+    ```
+
+=== "OnFinality"
+    ```
+    wss://moonbeam.api.onfinality.io/public-ws
+    ```

--- a/.snippets/code/endpoints/moonriver-http.md
+++ b/.snippets/code/endpoints/moonriver-http.md
@@ -1,0 +1,9 @@
+=== "Dwellir"
+    ```
+    https://moonriver-rpc.dwellir.com
+    ```
+
+=== "OnFinality"
+    ```
+    https://moonriver.api.onfinality.io/public
+    ```

--- a/.snippets/code/endpoints/moonriver-wss.md
+++ b/.snippets/code/endpoints/moonriver-wss.md
@@ -1,0 +1,9 @@
+=== "Dwellir"
+    ```
+    wss://moonriver-rpc.dwellir.com
+    ```
+
+=== "OnFinality"
+    ```
+    wss://moonriver.api.onfinality.io/public-ws
+    ```

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -25,6 +25,25 @@ Moonbase Alpha has two endpoints available for users to connect to: one for HTTP
 
 --8<-- 'text/testnet/relay-chain.md'
 
+Moonriver has two endpoints available for users to connect to: one for HTTPS and one for WSS.
+
+### HTTPS {: #https }
+
+--8<-- 'code/endpoints/moonriver-https.md'
+
+### WSS {: #wss }
+
+--8<-- 'code/endpoints/moonriver-wss.md'
+
+Moonbeam has two endpoints available for users to connect to: one for HTTPS and one for WSS.
+
+### HTTPS {: #https }
+
+--8<-- 'code/endpoints/moonbeam-https.md'
+
+### WSS {: #wss }
+
+--8<-- 'code/endpoints/moonbeam-wss.md'
 
 ## Endpoint Providers {: #endpoint-providers }
 


### PR DESCRIPTION
### Description

This PR adds Dwellir and OnFinality endpoints for Moonbeam and Moonriver

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
