### PR TITLE
update the runtime cache size value

### DIFF
--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -38,7 +38,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--telemetry-url`** - specifies the URL of the telemetry server to connect to. This flag can be passed multiple times as a means to specify multiple telemetry endpoints. This flag takes two parameters: the URL and the verbosity level. Verbosity levels range from 0-9, with 0 denoting the least verbosity. Expected format is '<URL VERBOSITY>', e.g. `--telemetry-url 'wss://foo/bar 0'`.
 - **`--in-peers`** - specifies the maximum amount of accepted incoming connections. The default is `25`
 - **`--out-peers`** - specifies the maximum amount of outgoing connections to maintain. The default is `25`
-- **`--runtime-cache-size 32`** - configures the number of different runtime versions preserved in the in-memory cache to 32
+- **`--runtime-cache-size 64`** - configures the number of different runtime versions preserved in the in-memory cache to 64
 - **`--eth-log-block-cache`** - size in bytes the LRU cache for block data is limited to use. This flag mostly pertains to RPC providers. The default is `300000000`
 - **`--eth-statuses-cache`** - size in bytes the LRU cache for transaction statuses data is limited to use. This flag mostly pertains to RPC providers. The default is `300000000` 
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -75,7 +75,7 @@ You will also need to start your node with the following flag(s) depending on th
   - **`--ethapi=trace`** - optional flag that enables `trace_filter` 
   - **`--ethapi=txpool`** - optional flag that enables `txpool_content`, `txpool_inspect`, and `txpool_status`
   - **`--wasm-runtime-overrides=/moonbeam/<network>-substitutes-tracing`** - **required** flag for tracing that specifies the path where the local WASM runtimes are stored. Accepts the network as a parameter: `moonbeam`, `moonriver`, or `moonbase` (for development nodes and Moonbase Alpha)
-  - **`--runtime-cache-size 32`** - **required** flag that configures the number of different runtime versions preserved in the in-memory cache to 32
+  - **`--runtime-cache-size 64`** - **required** flag that configures the number of different runtime versions preserved in the in-memory cache to 64
 
 The complete command for running a tracing node is as follows:
 
@@ -95,7 +95,7 @@ The complete command for running a tracing node is as follows:
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbeam-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -115,7 +115,7 @@ The complete command for running a tracing node is as follows:
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonriver-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -135,7 +135,7 @@ The complete command for running a tracing node is as follows:
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     -- \
     --execution wasm \
     --pruning 1000 \
@@ -150,7 +150,7 @@ The complete command for running a tracing node is as follows:
     --name="Moonbeam-Tutorial" \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
-    --runtime-cache-size 32 \
+    --runtime-cache-size 64 \
     --dev
     ```
 


### PR DESCRIPTION
### Description

Update the `--runtime-cache-size` flag value to be 64 instead of 32

Goes with CN PR# https://github.com/PureStake/moonbeam-docs-cn/pull/99