### PR TITLE
update treasury docs

### DIFF
--- a/learn/features/treasury.md
+++ b/learn/features/treasury.md
@@ -20,7 +20,8 @@ Some important terminology to understand in regards to treasuries:
 - **Council** — a group of elected individuals that control how treasury funds will be spent
 - **Proposal** — a plan or suggestion to further the network that is put forth by stakeholders to be approved by the council
 - **Proposal bond** — a deposit equal to a percentage of the total proposal spend amount
-- **Proposal bond minimum** — minimum amount for a proposal bond. This amount must be paid as the bond if it is higher than the deposit percentage
+- **Proposal bond minimum** — minimum amount for a proposal bond. This is the lower limit of the bond for a treasury proposal
+- **Proposal bond maximum** — maximum amount (cap) for a proposal bond. **Proposal bonds are currently uncapped in all Moonbeam-based networks**
 - **Spend period** — the amount of days, in blocks, during which the treasury funds as many proposals as possible without exceeding the maximum
 - **Maximum approved proposals** — the maximum amount of proposals that can wait in the spending queue
 
@@ -51,18 +52,17 @@ Some important terminology to understand in regards to treasuries:
     |   Maximum approved proposals    |  |                               {{ networks.moonbase.treasury.max_approved_proposals }}                                |
     | % of transaction fees allocated |  |                                  {{ networks.moonbase.treasury.tx_fees_allocated }}                                  |
 
-
 ## Community Treasury {: #community-treasury } 
 
-To fund the Treasury, a percentage of each block's transactions fees will be allocated to it. The remaining percentage of the fees are burned (check table above). The Treasury allows stakeholders to submit spending proposals to be reviewed and voted on by the Council. These spending proposals should include initiatives to further the network or boost network engagement. Some network initiatives could include funding integrations or collaborations, community events, network outreach, and more. 
+The Treasury is funded by a percentage of each block's transaction fees. The remaining percentage of the fees is burned (check the table above). The Treasury allows stakeholders to submit spending proposals to be reviewed and voted on by the Council. These spending proposals should include initiatives to further the network or boost network engagement. Some network initiatives could include funding integrations or collaborations, community events, network outreach, and more. 
 
-To deter spam, proposals must be submitted with a deposit, also known as a proposal bond. The proposal bond needs to be higher than the minimum amount, known as the proposal bond minimum, which can be changed by a governance proposal. So, any token holder that has enough tokens to cover the deposit can submit a proposal. If the proposer doesn't have enough funds to cover the deposit, the extrinsic will fail due to insufficient funds, but transaction fees will still be deducted. 
+To deter spam, proposals must be submitted with a deposit, also known as a proposal bond. The proposal bond is a percentage (check the table above) of the amount requested by the proposer, with a minimum amount and no upper limit (compared to Polkadot and Kusama, which have a maximum bond amount). A governance proposal can change these values. So, any token holder with enough tokens to cover the deposit can submit a proposal. If the proposer doesn't have enough funds to cover the deposit, the extrinsic will fail due to insufficient funds, but transaction fees will still be deducted. 
 
 Once a proposal has been submitted, the Council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the Council. On the other hand, the threshold for rejecting a proposal is at least one-half of the Council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted.
  
-If the proposal gets rejected, the deposit will be lost and transfered to the parachain treasury account. If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low.
+If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low. If the proposal gets rejected, the deposit will be lost and transferred to the parachain treasury account.
 
-Once the proposal is in a spend period, the funds will get distributed to the beneficiary and the original deposit will be returned to the proposer. If the treasury runs out of funds, the remaining approved proposals will remain in storage until the next spend period when the Treasury has enough funds again.
+Once the proposal is in a spend period, the funds will get distributed to the beneficiary, and the original deposit will be returned to the proposer. If the Treasury runs out of funds, the remaining approved proposals will remain in storage until the following spend period when the Treasury has enough funds again.
 
 The happy path for a treasury proposal is shown in the following diagram:
 

--- a/learn/features/treasury.md
+++ b/learn/features/treasury.md
@@ -58,7 +58,9 @@ To fund the Treasury, a percentage of each block's transactions fees will be all
 
 To deter spam, proposals must be submitted with a deposit, also known as a proposal bond. The proposal bond needs to be higher than the minimum amount, known as the proposal bond minimum, which can be changed by a governance proposal. So, any token holder that has enough tokens to cover the deposit can submit a proposal. If the proposer doesn't have enough funds to cover the deposit, the extrinsic will fail due to insufficient funds, but transaction fees will still be deducted. 
 
-Once a proposal has been submitted, is subject to governance, and the council votes on it. If the proposal gets rejected, the deposit will be lost and transfered to the treasury pot. If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low.
+Once a proposal has been submitted the Council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the Council. On the other hand, the threshold for rejecting a proposal is at least one-half of the Council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted
+ 
+If the proposal gets rejected, the deposit will be lost and transfered to the treasury pot. If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low.
 
 Once the proposal is in a spend period, the funds will get distributed to the beneficiary and the original deposit will be returned to the proposer. If the treasury runs out of funds, the remaining approved proposals will remain in storage until the next spend period when the Treasury has enough funds again.
 

--- a/learn/features/treasury.md
+++ b/learn/features/treasury.md
@@ -58,9 +58,9 @@ To fund the Treasury, a percentage of each block's transactions fees will be all
 
 To deter spam, proposals must be submitted with a deposit, also known as a proposal bond. The proposal bond needs to be higher than the minimum amount, known as the proposal bond minimum, which can be changed by a governance proposal. So, any token holder that has enough tokens to cover the deposit can submit a proposal. If the proposer doesn't have enough funds to cover the deposit, the extrinsic will fail due to insufficient funds, but transaction fees will still be deducted. 
 
-Once a proposal has been submitted the Council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the Council. On the other hand, the threshold for rejecting a proposal is at least one-half of the Council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted
+Once a proposal has been submitted, the Council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the Council. On the other hand, the threshold for rejecting a proposal is at least one-half of the Council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted.
  
-If the proposal gets rejected, the deposit will be lost and transfered to the treasury pot. If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low.
+If the proposal gets rejected, the deposit will be lost and transfered to the parachain treasury account. If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low.
 
 Once the proposal is in a spend period, the funds will get distributed to the beneficiary and the original deposit will be returned to the proposer. If the treasury runs out of funds, the remaining approved proposals will remain in storage until the next spend period when the Treasury has enough funds again.
 


### PR DESCRIPTION
### Description

This PR updates the treasury docs and adds clarity around voting thresholds and rejected proposals

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a