### PR TITLE
Add erc20 decoding section to Sidecar page

### DIFF
--- a/builders/build/canonical-contracts/precompiles/democracy.md
+++ b/builders/build/canonical-contracts/precompiles/democracy.md
@@ -122,7 +122,7 @@ On the next screen, take the following steps:
 1. Expand the Democracy precompile contract to see the available functions
 2. Find the **propose** function and press the button to expand the section
 3. Enter the hash of the proposal
-4. Enter the value in WEI of the tokens to bond. The minimum bond is  {{ networks.moonbase.democracy.min_deposit }} DEV, {{ networks.moonriver.democracy.min_deposit }} MOVR or {{ networks.moonbeam.democracy.min_deposit }} GLMR. For this example 4 DEV or `4000000000000000000` was entered
+4. Enter the value in Wei of the tokens to bond. The minimum bond is  {{ networks.moonbase.democracy.min_deposit }} DEV, {{ networks.moonriver.democracy.min_deposit }} MOVR or {{ networks.moonbeam.democracy.min_deposit }} GLMR. For this example 4 DEV or `4000000000000000000` was entered
 5. Press **transact** and confirm the transaction in MetaMask
 
 ![Call the propose function](/images/builders/build/canonical-contracts/precompiles/democracy/democracy-6.png)
@@ -196,7 +196,7 @@ Now, you're ready to return to Remix to vote on the referendum via the democracy
 2. Find the **standard_vote** function and press the button to expand the section
 3. Enter the index of the referendum to vote on
 4. Leave this field empty for nay or input 1 for aye. In the context of a referendum, nay is a vote to keep the status quo unchanged. Aye is a vote to enact the action proposed by the referendum
-5. Enter the number of tokens to lock in WEI. Avoid entering your full balance here because you need to pay for transaction fees
+5. Enter the number of tokens to lock in Wei. Avoid entering your full balance here because you need to pay for transaction fees
 6. Enter a conviction between 0-6 inclusive that represents the desired lock period for the tokens committed to the vote, where 0 represents no lock period and 6 represents the maximum lock period. For more information on lock periods, see [voting on a proposal](/tokens/governance/voting/)
 7. Press **transact** and confirm the transaction in MetaMask
 

--- a/builders/build/canonical-contracts/precompiles/staking.md
+++ b/builders/build/canonical-contracts/precompiles/staking.md
@@ -187,7 +187,7 @@ Now that you have obtained the [candidate delegator count](#get-the-candidate-de
 
 1. Find and expand the **delegate** function
 2. Enter the candidate address you would like to delegate (`{{ networks.moonbase.staking.candidates.address1 }}`)
-3. Provide the amount to delegate in WEI. There is a minimum of `{{networks.moonbase.staking.min_del_stake}}` tokens to delegate, so the lowest amount in WEI is `5000000000000000000`
+3. Provide the amount to delegate in Wei. There is a minimum of `{{networks.moonbase.staking.min_del_stake}}` tokens to delegate, so the lowest amount in Wei is `5000000000000000000`
 4. Enter the delegation count for the candidate
 5. Enter your delegation count
 6. Press **transact**

--- a/builders/build/eth-api/dev-env/openzeppelin/overview.md
+++ b/builders/build/eth-api/dev-env/openzeppelin/overview.md
@@ -21,14 +21,14 @@ Currently, the following OpenZeppelin products/solutions work on the different n
 
 |      **Product**      | **Moonbeam** | **Moonriver** | **Moonbase Alpha** | **Moonbase Dev Node** |
 |:---------------------:|:------------:|:-------------:|:------------------:|:---------------------:|
-| Contracts & Libraries |      ✓       |       ✓       |         ✓          |           ✓           |
-|    Contract Wizard    |      ✓       |       ✓       |         ✓          |           ✓           |
+| Contracts & libraries |      ✓       |       ✓       |         ✓          |           ✓           |
+|   Contracts Wizard    |      ✓       |       ✓       |         ✓          |           ✓           |
 |       Defender        |      ✓       |       ✓       |         ✓          |           X           |
 
 You will find a corresponding tutorial for each product in the following links:
 
- - [**Contract Wizard**](/builders/build/eth-api/dev-env/openzeppelin/contracts/#openzeppelin-contract-wizard) — where you'll find a guide on how to use OpenZeppelin web-based wizard to create different token contracts with different functionalities
- - [**Contracts & Libraries**](/builders/build/eth-api/dev-env/openzeppelin/contracts/#deploying-openzeppelin-contracts-on-moonbeam) — where you'll find tutorials to deploy the most common token contracts using OpenZeppelin's templates: ERC-20, ERC-721 and ERC-1155
+ - [**Contracts Wizard**](/builders/build/eth-api/dev-env/openzeppelin/contracts/#openzeppelin-contract-wizard) — where you'll find a guide on how to use OpenZeppelin web-based wizard to create different token contracts with different functionalities
+ - [**Contracts & libraries**](/builders/build/eth-api/dev-env/openzeppelin/contracts/#deploying-openzeppelin-contracts-on-moonbeam) — where you'll find tutorials to deploy the most common token contracts using OpenZeppelin's templates: ERC-20, ERC-721 and ERC-1155
  - [**Defender**](/builders/build/eth-api/dev-env/openzeppelin/defender/) — where you'll find a guide on how to use OpenZeppelin Defender to manage your smart contracts in the Moonbase Alpha TestNet. This guide can also be adapted for Moonbeam and Moonriver
 
 --8<-- 'text/disclaimers/third-party-content.md'

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -21,7 +21,7 @@ Running this service locally through NPM requires Node.js to be installed.
 
 --8<-- 'text/common/install-nodejs.md'
 
-#### Installing the Substrate API Sidecar {: #installing-the-substrate-api-sidecar }
+### Installing the Substrate API Sidecar {: #installing-the-substrate-api-sidecar }
 
 To install the Substrate API Sidecar service in the current directory, run this from the command line:
 
@@ -243,10 +243,59 @@ The EVM field mappings are then summarized as the following:
     |       EVM Hash       |      `extrinsics.{extrinsic number}.events.{event number}.data.2`       |
     | EVM Execution Status |      `extrinsics.{extrinsic number}.events.{event number}.data.3`       |
 
-
 !!! note
     EVM transaction nonce and signature fields are under `extrinsics.{extrinsic number}.args.transaction.{transaction type}`, whereas the `nonce` and `signature` fields under `extrinsics.{extrinsic number}` are the Substrate transaction nonce and signature, which are set to `null` for EVM transactions.
 
+!!! note
+    A successfully executed EVM transaction will return either `succeed: "Stopped"` or `succeed: "Returned"` under the "EVM Execution Status" field.
+
+### ERC-20 Token Transfers {: #erc-20-token-transfers }
+
+Events emitted by smart contracts such as an ERC-20 token contract deployed on Moonbeam can be decoded from Sidecar block JSON objects. The nesting structure is as following:
+
+```JSON
+RESPONSE JSON Block Object:
+    |--extrinsics
+        |--{extrinsic number}
+            |--method
+                |--pallet: "ethereum"
+                |--method: "transact"
+            |--signature:
+            |--nonce: 
+            |--args
+                |--transaction
+                    |--{transaction type}
+            |--hash
+            |--events
+                |--{event number}
+                    |--method
+                        |--pallet: "evm"
+                        |--method: "Log"
+                    |--data
+                        |--0
+                            |-- address
+                            |-- topics
+                                |--0
+                                |--1
+                                |--2
+					        |-- data
+            ...
+    ...
+
+```
+
+Moonbeam ERC-20 token transfers will emit the [`Transfer`](https://eips.ethereum.org/EIPS/eip-20){target=_blank} event which can be decoded as the following:
+
+
+|      Tx Information  |                            Block JSON Field                             |
+|:--------------------:|:-----------------------------------------------------------------------:|
+| ERC-20 Contract Address | `extrinsics.{extrinsic number}.events.{event number}.data.0.address` |
+| Event Signature Hash |     `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.0`|
+|   Sender Address     |    `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.1`    |
+|   Recipient Address  |    `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.2`    |
+|  Amount  |     `extrinsics.{extrinsic number}.events.{event number}.data.0.data`      |
+
+Other events emitted by EVM smart contracts can be decoded in a similar fashion, but the content of the topics and data fields will change depending on the definition of the specific event. 
 
 ### Computing Gas Used {: #computing-gas-used } 
 

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -205,49 +205,49 @@ The EVM field mappings are then summarized as the following:
     |:------------------------:|:-----------------------------------------------------------------------------:|
     |         Chain ID         |       `extrinsics.{extrinsic number}.args.transaction.eip1559.chainId`        |
     |          Nonce           |        `extrinsics.{extrinsic number}.args.transaction.eip1559.nonce`         |
-    | Max Priority Fee Per Gas | `extrinsics.{extrinsic number}.args.transaction.eip1559.maxPriorityFeePerGas` |
-    |     Max Fee Per Gas      |     `extrinsics.{extrinsic number}.args.transaction.eip1559.maxFeePerGas`     |
-    |        Gas Limit         |       `extrinsics.{extrinsic number}.args.transaction.eip1559.gasLimit`       |
-    |       Access List        |      `extrinsics.{extrinsic number}.args.transaction.eip1559.accessList`      |
+    | Max priority fee per gas | `extrinsics.{extrinsic number}.args.transaction.eip1559.maxPriorityFeePerGas` |
+    |     Max fee per gas      |     `extrinsics.{extrinsic number}.args.transaction.eip1559.maxFeePerGas`     |
+    |        Gas limit         |       `extrinsics.{extrinsic number}.args.transaction.eip1559.gasLimit`       |
+    |       Access list        |      `extrinsics.{extrinsic number}.args.transaction.eip1559.accessList`      |
     |        Signature         |    `extrinsics.{extrinsic number}.args.transaction.eip1559.oddYParity/r/s`    |
-    |      Sender Address      |         `extrinsics.{extrinsic number}.events.{event number}.data.0`          |
-    |    Recipient Address     |         `extrinsics.{extrinsic number}.events.{event number}.data.1`          |
-    |         EVM Hash         |         `extrinsics.{extrinsic number}.events.{event number}.data.2`          |
-    |   EVM Execution Status   |         `extrinsics.{extrinsic number}.events.{event number}.data.3`          |
+    |      Sender address      |         `extrinsics.{extrinsic number}.events.{event number}.data.0`          |
+    |    Recipient address     |         `extrinsics.{extrinsic number}.events.{event number}.data.1`          |
+    |         EVM hash         |         `extrinsics.{extrinsic number}.events.{event number}.data.2`          |
+    |   EVM execution status   |         `extrinsics.{extrinsic number}.events.{event number}.data.3`          |
 
 === "Legacy"
     |      EVM Field       |                         Block JSON Field                          |
     |:--------------------:|:-----------------------------------------------------------------:|
     |        Nonce         |   `extrinsics.{extrinsic number}.args.transaction.legacy.nonce`   |
-    |      Gas Price       | `extrinsics.{extrinsic number}.args.transaction.legacy.gasPrice`  |
-    |      Gas Limit       | `extrinsics.{extrinsic number}.args.transaction.legacy.gasLimit`  |
+    |      Gas price       | `extrinsics.{extrinsic number}.args.transaction.legacy.gasPrice`  |
+    |      Gas limit       | `extrinsics.{extrinsic number}.args.transaction.legacy.gasLimit`  |
     |        Value         |   `extrinsics.{extrinsic number}.args.transaction.legacy.value`   |
     |      Signature       | `extrinsics.{extrinsic number}.args.transaction.legacy.signature` |
-    |    Sender Address    |   `extrinsics.{extrinsic number}.events.{event number}.data.0`    |
-    |  Recipient Address   |   `extrinsics.{extrinsic number}.events.{event number}.data.1`    |
-    |       EVM Hash       |   `extrinsics.{extrinsic number}.events.{event number}.data.2`    |
-    | EVM Execution Status |   `extrinsics.{extrinsic number}.events.{event number}.data.3`    |
+    |    Sender address    |   `extrinsics.{extrinsic number}.events.{event number}.data.0`    |
+    |  Recipient address   |   `extrinsics.{extrinsic number}.events.{event number}.data.1`    |
+    |       EVM hash       |   `extrinsics.{extrinsic number}.events.{event number}.data.2`    |
+    | EVM execution status |   `extrinsics.{extrinsic number}.events.{event number}.data.3`    |
 
 === "EIP2930"
     |      EVM Field       |                            Block JSON Field                             |
     |:--------------------:|:-----------------------------------------------------------------------:|
     |       Chain ID       |    `extrinsics.{extrinsic number}.args.transaction.eip2930.chainId`     |
     |        Nonce         |     `extrinsics.{extrinsic number}.args.transaction.eip2930.nonce`      |
-    |       GasPrice       |    `extrinsics.{extrinsic number}.args.transaction.eip2930.gasPrice`    |
-    |       GasLimit       |    `extrinsics.{extrinsic number}.args.transaction.eip2930.gasLimit`    |
+    |      Gas price       |    `extrinsics.{extrinsic number}.args.transaction.eip2930.gasPrice`    |
+    |      Gas limit       |    `extrinsics.{extrinsic number}.args.transaction.eip2930.gasLimit`    |
     |        Value         |     `extrinsics.{extrinsic number}.args.transaction.eip2930.value`      |
-    |     Access List      |   `extrinsics.{extrinsic number}.args.transaction.eip2930.accessList`   |
+    |     Access list      |   `extrinsics.{extrinsic number}.args.transaction.eip2930.accessList`   |
     |      Signature       | `extrinsics.{extrinsic number}.args.transaction.eip2930.oddYParity/r/s` |
-    |    Sender Address    |      `extrinsics.{extrinsic number}.events.{event number}.data.0`       |
-    |  Recipient Address   |      `extrinsics.{extrinsic number}.events.{event number}.data.1`       |
-    |       EVM Hash       |      `extrinsics.{extrinsic number}.events.{event number}.data.2`       |
-    | EVM Execution Status |      `extrinsics.{extrinsic number}.events.{event number}.data.3`       |
+    |    Sender address    |      `extrinsics.{extrinsic number}.events.{event number}.data.0`       |
+    |  Recipient address   |      `extrinsics.{extrinsic number}.events.{event number}.data.1`       |
+    |       EVM hash       |      `extrinsics.{extrinsic number}.events.{event number}.data.2`       |
+    | EVM execution status |      `extrinsics.{extrinsic number}.events.{event number}.data.3`       |
 
 !!! note
-    EVM transaction nonce and signature fields are under `extrinsics.{extrinsic number}.args.transaction.{transaction type}`, whereas the `nonce` and `signature` fields under `extrinsics.{extrinsic number}` are the Substrate transaction nonce and signature, which are set to `null` for EVM transactions.
+    For Substrate transactions, the "Nonce" and "Signature" fields are under `extrinsics.{extrinsic number}`. For EVM transactions, the "Nonce" and "Signature" fields are under `extrinsics.{extrinsic number}.args.transaction.{transaction type}`, leaving the "Nonce" and "Signature" under `extrinsics.{extrinsic number}` to be `null`. 
 
-!!! note
     A successfully executed EVM transaction will return either `succeed: "Stopped"` or `succeed: "Returned"` under the "EVM Execution Status" field.
+
 
 ### ERC-20 Token Transfers {: #erc-20-token-transfers }
 
@@ -287,13 +287,13 @@ RESPONSE JSON Block Object:
 Moonbeam ERC-20 token transfers will emit the [`Transfer`](https://eips.ethereum.org/EIPS/eip-20){target=_blank} event which can be decoded as the following:
 
 
-|      Tx Information  |                            Block JSON Field                             |
-|:--------------------:|:-----------------------------------------------------------------------:|
-| ERC-20 Contract Address | `extrinsics.{extrinsic number}.events.{event number}.data.0.address` |
-| Event Signature Hash |     `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.0`|
-|   Sender Address     |    `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.1`    |
-|   Recipient Address  |    `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.2`    |
-|  Amount  |     `extrinsics.{extrinsic number}.events.{event number}.data.0.data`      |
+|     Tx Information      |                           Block JSON Field                            |
+|:-----------------------:|:---------------------------------------------------------------------:|
+| ERC-20 contract address | `extrinsics.{extrinsic number}.events.{event number}.data.0.address`  |
+|  Event signature hash   | `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.0` |
+|     Sender address      | `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.1` |
+|    Recipient address    | `extrinsics.{extrinsic number}.events.{event number}.data.0.topics.2` |
+|         Amount          |   `extrinsics.{extrinsic number}.events.{event number}.data.0.data`   |
 
 Other events emitted by EVM smart contracts can be decoded in a similar fashion, but the content of the topics and data fields will change depending on the definition of the specific event. 
 
@@ -325,17 +325,17 @@ The `Base Fee`, introduced in EIP 1559, is determined by the network itself. The
 === "Moonbeam"
     | Variable |  Value   |
     |:--------:|:--------:|
-    | Base Fee | 100 Gwei |
+    | Base fee | 100 Gwei |
 
 === "Moonriver"
     | Variable | Value  |
     |:--------:|:------:|
-    | Base Fee | 1 Gwei |
+    | Base fee | 1 Gwei |
 
 === "Moonbase Alpha"
     | Variable | Value  |
     |:--------:|:------:|
-    | Base Fee | 1 Gwei |
+    | Base fee | 1 Gwei |
 
 `Transaction Weight` is a Substrate mechanism used to manage the time it takes to validate a block. For all transactions types, `Transaction Weight` can be retrieved under the event of the relevant extrinsic where the `method` field is set to: 
 

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -297,6 +297,10 @@ Moonbeam ERC-20 token transfers will emit the [`Transfer`](https://eips.ethereum
 
 Other events emitted by EVM smart contracts can be decoded in a similar fashion, but the content of the topics and data fields will change depending on the definition of the specific event. 
 
+!!! note
+    The amount transferred is given in wei and in hexadecimal format. 
+
+
 ### Computing Gas Used {: #computing-gas-used } 
 
 To calculate the gas spent or used during EVM execution of the transaction, the following formula can be used: 

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -298,7 +298,7 @@ Moonbeam ERC-20 token transfers will emit the [`Transfer`](https://eips.ethereum
 Other events emitted by EVM smart contracts can be decoded in a similar fashion, but the content of the topics and data fields will change depending on the definition of the specific event. 
 
 !!! note
-    The amount transferred is given in wei and in hexadecimal format. 
+    The amount transferred is given in Wei and in hexadecimal format. 
 
 
 ### Computing Gas Used {: #computing-gas-used } 

--- a/builders/integrations/bridges/chainbridge.md
+++ b/builders/integrations/bridges/chainbridge.md
@@ -197,7 +197,7 @@ After adding the Bridge contract to Remix and compiling it, in order to send ERC
 1. Load the bridge contract address and click **At Address**
 2. To call the `sendERC20SToken()` function, enter the destination chain ID (For this example Kovan is being used: `42`)
 3. Enter the recipient address on the other side of the bridge
-4. Add the amount to transfer in WEI
+4. Add the amount to transfer in Wei
 5. Click **transact** and then MetaMask should pop-up asking you to sign the transaction 
 
 Once the transaction is confirmed, the process can take around 3 minutes to complete, after which you should have received the tokens in Kovan!

--- a/builders/integrations/indexers/covalent.md
+++ b/builders/integrations/indexers/covalent.md
@@ -61,14 +61,14 @@ The Covalent API has two classes of endpoints:
 
 ### Request Formatting {: #request-formatting } 
 
-| Endpoint                    |  | Format                                                              |
-|:----------------------------|::|:--------------------------------------------------------------------|
-| Balances                    |  | api.covalenthq.com/v1/1287/address/{address}/balances_v2/           |
-| Transactions                |  | api.covalenthq.com/v1/1287/address/{address}/transactions_v2/       |
-| Transfers                   |  | api.covalenthq.com/v1/1287/address/{address}/transfers_v2/          |
-| Token Holders               |  | api.covalenthq.com/v1/1287/tokens/{contract_address}/token_holders/ |
-| Log Events (Smart Contract) |  | api.covalenthq.com/v1/1287/events/address/{contract_address}/       |
-| Log Events (Topic Hash)     |  | api.covalenthq.com/v1/1287/events/topics/{topic}/                   |
+|          Endpoint           |                               Format                                |
+|:---------------------------:|:-------------------------------------------------------------------:|
+|          Balances           |      api.covalenthq.com/v1/1287/address/{address}/balances_v2/      |
+|        Transactions         |    api.covalenthq.com/v1/1287/address/{address}/transactions_v2/    |
+|          Transfers          |     api.covalenthq.com/v1/1287/address/{address}/transfers_v2/      |
+|        Token holders        | api.covalenthq.com/v1/1287/tokens/{contract_address}/token_holders/ |
+| Log events (smart contract) |    api.covalenthq.com/v1/1287/events/address/{contract_address}/    |
+|   Log events (topic hash)   |          api.covalenthq.com/v1/1287/events/topics/{topic}/          |
 
 ## Checking Prerequisites {: #checking-prerequisites } 
 

--- a/builders/integrations/oracles/razor-network.md
+++ b/builders/integrations/oracles/razor-network.md
@@ -13,19 +13,19 @@ Developers can now fetch prices from Razor Network’s oracle using a Bridge con
 
 To access these price feeds, we need to interact with the Bridge contract address, which can be found in the following table:
 
-|     Network    | |         Contract Address        |
-|:--------------:|-|:------------------------------------------:|
-| Moonbase Alpha | | 0x53f7660Ea48289B5DA42f1d79Eb9d4F5eB83D3BE |
+|    Network     |              Contract Address              |
+|:--------------:|:------------------------------------------:|
+| Moonbase Alpha | 0x53f7660Ea48289B5DA42f1d79Eb9d4F5eB83D3BE |
 
 ## Jobs {: #jobs } 
 
 Each data-feed has a Job ID attached to it. For example:
 
-|    Job ID    | |    Underlying Price [USD]  |
-|:------------:|-|:--------------------------:|
-|       1      | |            ETH             |
-|       2      | |            BTC             |
-|       3      | |      Microsoft Stocks      |
+| Job ID | Underlying Price [USD] |
+|:------:|:----------------------:|
+|   1    |          ETH           |
+|   2    |          BTC           |
+|   3    |    Microsoft Stocks    |
 
 You can check Job IDs for each data-feed at the following [link](https://razorscan.io/#/custom). Price feeds are updated every 5 minutes. More information can be found in [Razor's documentation website][https://docs.razor.network/].
 

--- a/node-operators/networks/run-a-node/overview.md
+++ b/node-operators/networks/run-a-node/overview.md
@@ -13,11 +13,11 @@ Running a full node on a Moonbeam-based network allows you to connect to the net
 
 There are multiple deployments of Moonbeam, including the Moonbase Alpha TestNet, Moonriver on Kusama, and Moonbeam on Polkadot. Here's how these environments are named and their corresponding [chain specification file](https://substrate.dev/docs/en/knowledgebase/integrate/chain-spec) names:
 
-|    Network     |  | Hosted By |  |             Chain Name              |
-|:--------------:|::|:---------:|::|:-----------------------------------:|
-| Moonbase Alpha |  | PureStake |  | {{ networks.moonbase.chain_spec }}  |
-|   Moonriver    |  |  Kusama   |  | {{ networks.moonriver.chain_spec }} |
-|    Moonbeam    |  | Polkadot  |  | {{ networks.moonbeam.chain_spec }}  |
+|    Network     | Hosted By |             Chain Name              |
+|:--------------:|:---------:|:-----------------------------------:|
+| Moonbase Alpha | PureStake | {{ networks.moonbase.chain_spec }}  |
+|   Moonriver    |  Kusama   | {{ networks.moonriver.chain_spec }} |
+|    Moonbeam    | Polkadot  | {{ networks.moonbeam.chain_spec }}  |
 
 !!! note
     Moonbase Alpha is still considered an Alphanet, and as such _will not_ have 100% uptime. The parachain might be purged as needed. During the development of your application, make sure you implement a method to redeploy your contracts and accounts to a fresh parachain quickly. If a chain purge is required, it will be announced via our [Discord channel](https://discord.gg/PfpUATX) at least 24 hours in advance.
@@ -29,28 +29,28 @@ Running a parachain node is similar to a typical Substrate node, but there are s
 The minimum specs recommended to run a node are shown in the following table. For our Kusama and Polkadot MainNet deployments, disk requirements will be higher as the network grows.
 
 === "Moonbeam"
-    |  Component   |  | Requirement                                                                                                                |
-    |:------------:|::|:---------------------------------------------------------------------------------------------------------------------------|
-    |   **CPU**    |  | {{ networks.moonbeam.node.cores }} Cores (Fastest per core speed)                                                          |
-    |   **RAM**    |  | {{ networks.moonbeam.node.ram }} GB                                                                                        |
-    |   **SSD**    |  | {{ networks.moonbeam.node.hd }} GB (to start)                                                                              |
-    | **Firewall** |  | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
+    |  Component   |                                                        Requirement                                                         |
+    |:------------:|:--------------------------------------------------------------------------------------------------------------------------:|
+    |   **CPU**    |                             {{ networks.moonbeam.node.cores }} Cores (Fastest per core speed)                              |
+    |   **RAM**    |                                            {{ networks.moonbeam.node.ram }} GB                                             |
+    |   **SSD**    |                                       {{ networks.moonbeam.node.hd }} GB (to start)                                        |
+    | **Firewall** | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
 
 === "Moonriver"
-    |  Component   |  | Requirement                                                                                                                |
-    |:------------:|::|:---------------------------------------------------------------------------------------------------------------------------|
-    |   **CPU**    |  | {{ networks.moonriver.node.cores }} Cores (Fastest per core speed)                                                         |
-    |   **RAM**    |  | {{ networks.moonriver.node.ram }} GB                                                                                       |
-    |   **SSD**    |  | {{ networks.moonriver.node.hd }} GB (to start)                                                                             |
-    | **Firewall** |  | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
+    |  Component   |                                                        Requirement                                                         |
+    |:------------:|:--------------------------------------------------------------------------------------------------------------------------:|
+    |   **CPU**    |                             {{ networks.moonriver.node.cores }} Cores (Fastest per core speed)                             |
+    |   **RAM**    |                                            {{ networks.moonriver.node.ram }} GB                                            |
+    |   **SSD**    |                                       {{ networks.moonriver.node.hd }} GB (to start)                                       |
+    | **Firewall** | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
 
 === "Moonbase Alpha"
-    |  Component   |  | Requirement                                                                                                                |
-    |:------------:|::|:---------------------------------------------------------------------------------------------------------------------------|
-    |   **CPU**    |  | {{ networks.moonbase.node.cores }} Cores (Fastest per core speed)                                                          |
-    |   **RAM**    |  | {{ networks.moonbase.node.ram }} GB                                                                                        |
-    |   **SSD**    |  | {{ networks.moonbase.node.hd }} GB (to start)                                                                              |
-    | **Firewall** |  | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
+    |  Component   |                                                        Requirement                                                         |
+    |:------------:|:--------------------------------------------------------------------------------------------------------------------------:|
+    |   **CPU**    |                             {{ networks.moonbase.node.cores }} Cores (Fastest per core speed)                              |
+    |   **RAM**    |                                            {{ networks.moonbase.node.ram }} GB                                             |
+    |   **SSD**    |                                       {{ networks.moonbase.node.hd }} GB (to start)                                        |
+    | **Firewall** | P2P port must be open to incoming traffic:<br>&nbsp; &nbsp; - Source: Any<br>&nbsp; &nbsp; - Destination: 30333, 30334 TCP |
 
 !!! note
     If you don't see an `Imported` message (without the `[Relaychain]` tag) when running a node, you might need to double-check your port configuration.
@@ -63,21 +63,21 @@ The only ports that need to be open for incoming traffic are those designated fo
 
 ### Default Ports for a Parachain Full-Node {: #default-ports-for-a-parachain-full-node } 
 
-|  Description   |  |                Port                 |
-|:--------------:|::|:-----------------------------------:|
-|    **P2P**     |  | {{ networks.parachain.p2p }} (TCP)  |
-|    **RPC**     |  |    {{ networks.parachain.rpc }}     |
-|     **WS**     |  |     {{ networks.parachain.ws }}     |
-| **Prometheus** |  | {{ networks.parachain.prometheus }} |
+|  Description   |                Port                 |
+|:--------------:|:-----------------------------------:|
+|    **P2P**     | {{ networks.parachain.p2p }} (TCP)  |
+|    **RPC**     |    {{ networks.parachain.rpc }}     |
+|     **WS**     |     {{ networks.parachain.ws }}     |
+| **Prometheus** | {{ networks.parachain.prometheus }} |
 
 ### Default Ports of Embedded Relay Chain {: #default-ports-of-embedded-relay-chain } 
 
-|  Description   |  |                 Port                  |
-|:--------------:|::|:-------------------------------------:|
-|    **P2P**     |  | {{ networks.relay_chain.p2p }} (TCP)  |
-|    **RPC**     |  |    {{ networks.relay_chain.rpc }}     |
-|     **WS**     |  |     {{ networks.relay_chain.ws }}     |
-| **Prometheus** |  | {{ networks.relay_chain.prometheus }} |
+|  Description   |                 Port                  |
+|:--------------:|:-------------------------------------:|
+|    **P2P**     | {{ networks.relay_chain.p2p }} (TCP)  |
+|    **RPC**     |    {{ networks.relay_chain.rpc }}     |
+|     **WS**     |     {{ networks.relay_chain.ws }}     |
+| **Prometheus** | {{ networks.relay_chain.prometheus }} |
 
 ## Installation {: #installation }
 

--- a/tokens/governance/proposals.md
+++ b/tokens/governance/proposals.md
@@ -33,26 +33,26 @@ Some of the key parameters for this guide are the following:
 === "Moonbeam"
     |         Variable         |                                                          Value                                                          |
     |:------------------------:|:-----------------------------------------------------------------------------------------------------------------------:|
-    |      Launch Period       | {{ networks.moonbeam.democracy.launch_period.blocks}} blocks ({{ networks.moonbeam.democracy.launch_period.days}} days) |
-    |     Cool-off Period      |   {{ networks.moonbeam.democracy.cool_period.blocks}} blocks ({{ networks.moonbeam.democracy.cool_period.days}} days)   |
-    | Minimum Preimage Deposit |                                 {{ networks.moonbeam.democracy.min_preim_deposit}} GLMR                                 |
-    | Minimum Proposal Deposit |                                    {{ networks.moonbeam.democracy.min_deposit}} GLMR                                    |
+    |      Launch period       | {{ networks.moonbeam.democracy.launch_period.blocks}} blocks ({{ networks.moonbeam.democracy.launch_period.days}} days) |
+    |     Cool-off period      |   {{ networks.moonbeam.democracy.cool_period.blocks}} blocks ({{ networks.moonbeam.democracy.cool_period.days}} days)   |
+    | Minimum preimage deposit |                                 {{ networks.moonbeam.democracy.min_preim_deposit}} GLMR                                 |
+    | Minimum proposal deposit |                                    {{ networks.moonbeam.democracy.min_deposit}} GLMR                                    |
 
 === "Moonriver"
     |         Variable         |                                                           Value                                                           |
     |:------------------------:|:-------------------------------------------------------------------------------------------------------------------------:|
-    |      Launch Period       | {{ networks.moonriver.democracy.launch_period.blocks}} blocks ({{ networks.moonriver.democracy.launch_period.days}} days) |
-    |     Cool-off Period      |   {{ networks.moonriver.democracy.cool_period.blocks}} blocks ({{ networks.moonriver.democracy.cool_period.days}} days)   |
-    | Minimum Preimage Deposit |                                 {{ networks.moonriver.democracy.min_preim_deposit}} MOVR                                  |
-    | Minimum Proposal Deposit |                                    {{ networks.moonriver.democracy.min_deposit}} MOVR                                     |
+    |      Launch period       | {{ networks.moonriver.democracy.launch_period.blocks}} blocks ({{ networks.moonriver.democracy.launch_period.days}} days) |
+    |     Cool-off period      |   {{ networks.moonriver.democracy.cool_period.blocks}} blocks ({{ networks.moonriver.democracy.cool_period.days}} days)   |
+    | Minimum preimage deposit |                                 {{ networks.moonriver.democracy.min_preim_deposit}} MOVR                                  |
+    | Minimum proposal deposit |                                    {{ networks.moonriver.democracy.min_deposit}} MOVR                                     |
 
 === "Moonbase Alpha"
     |         Variable         |                                                          Value                                                          |
     |:------------------------:|:-----------------------------------------------------------------------------------------------------------------------:|
-    |      Launch Period       | {{ networks.moonbase.democracy.launch_period.blocks}} blocks ({{ networks.moonbase.democracy.launch_period.days}} days) |
-    |     Cool-off Period      |   {{ networks.moonbase.democracy.cool_period.blocks}} blocks ({{ networks.moonbase.democracy.cool_period.days}} days)   |
-    | Minimum Preimage Deposit |                                 {{ networks.moonbase.democracy.min_preim_deposit}} DEV                                  |
-    | Minimum Proposal Deposit |                                    {{ networks.moonbase.democracy.min_deposit}} DEV                                     |
+    |      Launch period       | {{ networks.moonbase.democracy.launch_period.blocks}} blocks ({{ networks.moonbase.democracy.launch_period.days}} days) |
+    |     Cool-off period      |   {{ networks.moonbase.democracy.cool_period.blocks}} blocks ({{ networks.moonbase.democracy.cool_period.days}} days)   |
+    | Minimum preimage deposit |                                 {{ networks.moonbase.democracy.min_preim_deposit}} DEV                                  |
+    | Minimum proposal deposit |                                    {{ networks.moonbase.democracy.min_deposit}} DEV                                     |
 
 
 This guide will show you how to submit a proposal on Moonbase Alpha. It can be adapted for Moonbeam or Moonriver.

--- a/tokens/governance/voting.md
+++ b/tokens/governance/voting.md
@@ -36,23 +36,23 @@ Some of the key parameters for this guide are the following:
 === "Moonbeam"
     |        Variable         |                                                         Value                                                         |
     |:-----------------------:|:---------------------------------------------------------------------------------------------------------------------:|
-    |      Enact Period       | {{ networks.moonbeam.democracy.enact_period.blocks}} blocks ({{ networks.moonbeam.democracy.enact_period.days}} days) |
-    | Maximum Number of Votes |                                      {{ networks.moonbeam.democracy.max_votes}}                                       |
-    |       Vote Period       |  {{ networks.moonbeam.democracy.vote_period.blocks}} blocks ({{ networks.moonbeam.democracy.vote_period.days}} days)  |
+    |      Enact period       | {{ networks.moonbeam.democracy.enact_period.blocks}} blocks ({{ networks.moonbeam.democracy.enact_period.days}} days) |
+    | Maximum number of votes |                                      {{ networks.moonbeam.democracy.max_votes}}                                       |
+    |       Vote period       |  {{ networks.moonbeam.democracy.vote_period.blocks}} blocks ({{ networks.moonbeam.democracy.vote_period.days}} days)  |
 
 === "Moonriver"
     |        Variable         |                                                          Value                                                          |
     |:-----------------------:|:-----------------------------------------------------------------------------------------------------------------------:|
-    |      Enact Period       | {{ networks.moonriver.democracy.enact_period.blocks}} blocks ({{ networks.moonriver.democracy.enact_period.days}} days) |
-    | Maximum Number of Votes |                                       {{ networks.moonriver.democracy.max_votes}}                                       |
-    |       Vote Period       |  {{ networks.moonriver.democracy.vote_period.blocks}} blocks ({{ networks.moonriver.democracy.vote_period.days}} days)  |
+    |      Enact period       | {{ networks.moonriver.democracy.enact_period.blocks}} blocks ({{ networks.moonriver.democracy.enact_period.days}} days) |
+    | Maximum number of votes |                                       {{ networks.moonriver.democracy.max_votes}}                                       |
+    |       Vote period       |  {{ networks.moonriver.democracy.vote_period.blocks}} blocks ({{ networks.moonriver.democracy.vote_period.days}} days)  |
 
 === "Moonbase Alpha"
     |        Variable         |                                                         Value                                                         |
     |:-----------------------:|:---------------------------------------------------------------------------------------------------------------------:|
-    |      Enact Period       | {{ networks.moonbase.democracy.enact_period.blocks}} blocks ({{ networks.moonbase.democracy.enact_period.days}} days) |
-    | Maximum Number of Votes |                                      {{ networks.moonbase.democracy.max_votes}}                                       |
-    |       Vote Period       |  {{ networks.moonbase.democracy.vote_period.blocks}} blocks ({{ networks.moonbase.democracy.vote_period.days}} days)  |
+    |      Enact period       | {{ networks.moonbase.democracy.enact_period.blocks}} blocks ({{ networks.moonbase.democracy.enact_period.days}} days) |
+    | Maximum number of votes |                                      {{ networks.moonbase.democracy.max_votes}}                                       |
+    |       Vote period       |  {{ networks.moonbase.democracy.vote_period.blocks}} blocks ({{ networks.moonbase.democracy.vote_period.days}} days)  |
 
 This guide will show you how to vote on a referendum on Moonbase Alpha. It can be adapted for Moonbeam or Moonriver.
 

--- a/tokens/manage/identity.md
+++ b/tokens/manage/identity.md
@@ -24,23 +24,23 @@ To store your information on-chain, you must bond some funds, which eventually w
 === "Moonbeam"
     |       Variable        |                               Definition                                |                      Value                      |
     |:---------------------:|:-----------------------------------------------------------------------:|:-----------------------------------------------:|
-    |     Basic Deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonbeam.identity.basic_dep }} GLMR |
-    |     Field Deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonbeam.identity.field_dep }} GLMR |
-    | Max Additional Fields |     Maximum number of additional fields that may be stored in an ID     |   {{ networks.moonbeam.identity.max_fields }}   |
+    |     Basic deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonbeam.identity.basic_dep }} GLMR |
+    |     Field deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonbeam.identity.field_dep }} GLMR |
+    | Max additional fields |     Maximum number of additional fields that may be stored in an ID     |   {{ networks.moonbeam.identity.max_fields }}   |
 
 === "Moonriver"
     |       Variable        |                               Definition                                |                      Value                       |
     |:---------------------:|:-----------------------------------------------------------------------:|:------------------------------------------------:|
-    |     Basic Deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonriver.identity.basic_dep }} MOVR |
-    |     Field Deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonriver.identity.field_dep }} MOVR |
-    | Max Additional Fields |     Maximum number of additional fields that may be stored in an ID     |   {{ networks.moonriver.identity.max_fields }}   |
+    |     Basic deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonriver.identity.basic_dep }} MOVR |
+    |     Field deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonriver.identity.field_dep }} MOVR |
+    | Max additional fields |     Maximum number of additional fields that may be stored in an ID     |   {{ networks.moonriver.identity.max_fields }}   |
 
 === "Moonbase Alpha"
     |       Variable        |                               Definition                                |                     Value                      |
     |:---------------------:|:-----------------------------------------------------------------------:|:----------------------------------------------:|
-    |     Basic Deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonbase.identity.basic_dep }} DEV |
-    |     Field Deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonbase.identity.field_dep }} DEV |
-    | Max Additional Fields |     Maximum number of additional fields that may be stored in an ID     |  {{ networks.moonbase.identity.max_fields }}   |
+    |     Basic deposit     |           The amount held on deposit for setting an identity            | {{ networks.moonbase.identity.basic_dep }} DEV |
+    |     Field deposit     | The amount held on deposit per additional field for setting an identity | {{ networks.moonbase.identity.field_dep }} DEV |
+    | Max additional fields |     Maximum number of additional fields that may be stored in an ID     |  {{ networks.moonbase.identity.max_fields }}   |
 
 ## Checking Prerequisites { : #checking-prerequisites }
 

--- a/tokens/staking/stake.md
+++ b/tokens/staking/stake.md
@@ -83,10 +83,10 @@ This section goes over the process of delegating collator candidates.
 
 The tutorial will use the following candidates on Moonbase Alpha as a reference:
 
-|  Variable   |  |                       Address                       |
-|:-----------:|::|:---------------------------------------------------:|
-| Candidate 1 |  | {{ networks.moonbase.staking.candidates.address1 }} |
-| Candidate 2 |  | {{ networks.moonbase.staking.candidates.address2 }} |
+|  Variable   |                       Address                       |
+|:-----------:|:---------------------------------------------------:|
+| Candidate 1 | {{ networks.moonbase.staking.candidates.address1 }} |
+| Candidate 2 | {{ networks.moonbase.staking.candidates.address2 }} |
 
 Before staking via Polkadot.js Apps, you need to retrieve some important parameters.
 


### PR DESCRIPTION
### Description

Adds a section on decoding ERC-20 transfers from Sidecar API to the Sidecar page.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [x] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
