### PR TITLE
update faucet dispensed amount

### DIFF
--- a/variables.yml
+++ b/variables.yml
@@ -26,7 +26,7 @@ networks:
     min_gas_price: 1
     block_time: 12
     discord_faucet_amount: 1 DEV token
-    website_faucet_amount: 5 DEV tokens
+    website_faucet_amount: 1.1 DEV tokens
     node:
       cores: 8
       ram: 16


### PR DESCRIPTION
### Description

Changes the dispensed amount of DEV tokens from the website faucet to 1.1 (from 5) DEV 

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a