### PR TITLE
Adds Sidecar code snippet to Transfers API page

### DIFF
--- a/.snippets/code/vs-ethereum/sidecar-transfer.md
+++ b/.snippets/code/vs-ethereum/sidecar-transfer.md
@@ -1,0 +1,68 @@
+```ts
+import axios from 'axios';
+
+// This script will decode all native token transfers (Substrate & Ethereum) in a given Sidecar block, and extract the tx hash. It can be adapted for any Moonbeam network. 
+
+// Endpoint to retrieve the latest block
+const endpoint = 'http://127.0.0.1:8080/blocks/head';
+
+async function main() {
+    try {
+        // Retrieve the block from the Sidecar endpoint
+        const response = await axios.get(endpoint);
+        // Retrieve the block height of the current block
+        console.log('Block Height: '+response.data.number)
+
+        // Iterate through all extrinsics in the block
+        response.data.extrinsics.forEach(extrinsic => {
+            
+            // Retrieve Ethereum Transfers
+            if (extrinsic.method.pallet === 'ethereum' && extrinsic.method.method === 'transact'){
+                // Get the value for any of the three EIP transaction standards supported
+                const value = extrinsic.args.transaction.legacy && extrinsic.args.transaction.legacy.value || extrinsic.   args.transaction.eip1559 && extrinsic.args.transaction.eip1559.value || extrinsic.args.transaction.eip2930 && extrinsic.args.transaction.eip2930.value;
+
+                // Iterate through the events to get transaction details
+                extrinsic.events.forEach(event => {
+                    if (event.method.pallet === 'ethereum' && event.method.method === 'Executed') {
+                        console.log('From: ' + event.data[0]);
+                        console.log('To: ' + event.data[1]);
+                        console.log('Tx Hash: ' + event.data[2]);
+                        console.log('Value: ' + value);
+                        // Check the execution status
+                        if (event.data[3].succeed) {
+                            console.log('Status: Success')
+                        }
+                        else {
+                            console.log('Status: Failed')
+                        }
+                    }
+                });
+            }
+
+            // Retrieve Substrate Transfers
+            if ((extrinsic.method.pallet === 'balances' && (extrinsic.method.method === 'transferKeepAlive' || extrinsic.method.method === 'transfer'))){
+                // Iterate through the events to get transaction details
+                extrinsic.events.forEach(event => {
+                    if (event.method.pallet === 'balances' && event.method.method === 'Transfer') {
+                        console.log('From: ' + event.data[0]);
+                        console.log('To: ' + event.data[1]);
+                        console.log('Tx Hash: ' + extrinsic.hash);
+                        console.log('Value: ' + event.data[2]);
+                        // Check the execution status
+                        if (extrinsic.success) {
+                            console.log('Status: Success')
+                        }
+                        else {
+                            console.log('Status: Failed')
+                        }
+                    }
+                });
+            }
+        });
+    } catch (err) {
+        console.log(err);
+    }
+}
+
+main();
+```

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -351,3 +351,7 @@ And then `Transaction Weight` is mapped to the following field of the block JSON
 ```
 extrinsics.{extrinsic number}.events.{event number}.data.0.weight
 ```
+
+## Sample Code for Monitoring Native Token Transfers { #sample-code-for-monitoring-native-token-transfers }
+
+The [Transfers API page](/builders/build/get-started/eth-compare/transfers-api/#using-substrate-api-sidecar){target=_blank} has a code snippet demonstrating how to use Substrate API Sidecar to retrieve and decode native token transfers on Moonbeam networks. You can reference that as a starting point to build out backends that utilizes Sidecar to listen to transfers on Moonbeam networks. 

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -354,4 +354,4 @@ extrinsics.{extrinsic number}.events.{event number}.data.0.weight
 
 ## Sample Code for Monitoring Native Token Transfers { #sample-code-for-monitoring-native-token-transfers }
 
-The [Transfers API page](/builders/build/get-started/eth-compare/transfers-api/#using-substrate-api-sidecar){target=_blank} has a code snippet demonstrating how to use Substrate API Sidecar to retrieve and decode native token transfers on Moonbeam networks. You can reference that as a starting point to build out backends that utilizes Sidecar to listen to transfers on Moonbeam networks. 
+The [Transfers API page](/builders/build/get-started/eth-compare/transfers-api/#using-substrate-api-sidecar){target=_blank} has a code snippet demonstrating how to use Substrate API Sidecar to retrieve and decode native token transfers sent with both Substrate and Ethereum API on Moonbeam networks. You can reference that as a starting point to build out backends that utilizes Sidecar to listen to transfers on Moonbeam networks. 

--- a/builders/build/substrate-api/sidecar.md
+++ b/builders/build/substrate-api/sidecar.md
@@ -354,4 +354,4 @@ extrinsics.{extrinsic number}.events.{event number}.data.0.weight
 
 ## Sample Code for Monitoring Native Token Transfers { #sample-code-for-monitoring-native-token-transfers }
 
-The [Transfers API page](/builders/build/get-started/eth-compare/transfers-api/#using-substrate-api-sidecar){target=_blank} has a code snippet demonstrating how to use Substrate API Sidecar to retrieve and decode native token transfers sent with both Substrate and Ethereum API on Moonbeam networks. You can reference that as a starting point to build out backends that utilizes Sidecar to listen to transfers on Moonbeam networks. 
+The [Transfers API page](/builders/build/get-started/eth-compare/transfers-api/#using-substrate-api-sidecar){target=_blank} has a code snippet demonstrating how to use Substrate API Sidecar to retrieve and decode native token transfers sent with both Substrate and Ethereum API on Moonbeam networks. You can reference that as a starting point to build out backends that utilize Sidecar to listen to transfers on Moonbeam networks. 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -43,6 +43,8 @@ All the scenarios described above will effectively transfer base layer network t
 
 ## Monitor Native Token Balance Transfers {: #monitor-transfers }
 
+The following code samples will illustrate how to listen to both types of transfers, sent via Substrate or Ethereum API, using either the [Polkadot.js API library](https://polkadot.js.org/docs/api/start){target=_blank} or [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}. The following code snippets are for demo purposes only and should not be used without modification and testing in a production environment. 
+
 ### Using Polkadot.js API {: #using-polkadotjs-api }
 
 The [Polkadot.js API package](https://polkadot.js.org/docs/api/start){target=_blank} provides developers a way to interact with Substrate chains using JavaScript.
@@ -55,7 +57,7 @@ In addition, you can find more sample code snippets related to more specific cas
 
 ### Using Substrate API Sidecar {: #using-substrate-api-sidecar }
 
-Developers can also retrieve Moonbeam blocks and monitor transactions using [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}, a REST API service for interacting with blockchains built with the Substrate framework. 
+Developers can also retrieve Moonbeam blocks and monitor transactions sent via both the Substrate and Ethereum API using [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}, a REST API service for interacting with blockchains built with the Substrate framework. 
 
 The following code snippet uses the Axios HTTP client to query the Sidecar endpoint `/blocks/head`(https://paritytech.github.io/substrate-api-sidecar/dist/){target=_blank} for the latest finalized block, and then decodes the block for the the `from`, `to`, `value`, `tx hash` and `transaction status` of native token transfers at both the EVM and Substrate API level. 
 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -61,7 +61,7 @@ The following code snippet uses the Axios HTTP client to query the Sidecar endpo
 
 --8<-- 'code/vs-ethereum/sidecar-transfer.md'
 
-You can reference the [Substrate API Sidecar page](/builders/build/substrate-api/sidecar/) for information on installing and running your own Sidecar service instance, as well as more details on how to decode Sidecar blocks for Moonbeam transaction related information. 
+You can reference the [Substrate API Sidecar page](/builders/build/substrate-api/sidecar/) for information on installing and running your own Sidecar service instance, as well as more details on how to decode Sidecar blocks for Moonbeam transactions. 
 
 
 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -43,7 +43,7 @@ All the scenarios described above will effectively transfer base layer network t
 
 ## Monitor Native Token Balance Transfers {: #monitor-transfers }
 
-The following code samples will illustrate how to listen to both types of transfers, sent via Substrate or Ethereum API, using either the [Polkadot.js API library](https://polkadot.js.org/docs/api/start){target=_blank} or [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}. The following code snippets are for demo purposes only and should not be used without modification and testing in a production environment. 
+The following code samples will demonstrate how to listen to both types of native token transfers, sent via Substrate or Ethereum API, using either the [Polkadot.js API library](https://polkadot.js.org/docs/api/start){target=_blank} or [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}. The following code snippets are for demo purposes only and should not be used without modification and further testing in a production environment. 
 
 ### Using Polkadot.js API {: #using-polkadotjs-api }
 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -64,6 +64,3 @@ The following code snippet uses the Axios HTTP client to query the Sidecar endpo
 --8<-- 'code/vs-ethereum/sidecar-transfer.md'
 
 You can reference the [Substrate API Sidecar page](/builders/build/substrate-api/sidecar/) for information on installing and running your own Sidecar service instance, as well as more details on how to decode Sidecar blocks for Moonbeam transactions. 
-
-
-

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -57,7 +57,7 @@ In addition, you can find more sample code snippets related to more specific cas
 
 Developers can also retrieve Moonbeam blocks and monitor transactions using [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}, a REST API service for interacting with blockchains built with the Substrate framework. 
 
-The following code snippet uses the Axios HTTP client to query the Sidecar endpoint `/blocks/head`(https://paritytech.github.io/substrate-api-sidecar/dist/){target=_blank} for the latest finalized block, and then decodes the block for the the `from`, `to`, `amount`, `tx hash` and `transaction status` of native token transfers at both the EVM and Substrate API level. 
+The following code snippet uses the Axios HTTP client to query the Sidecar endpoint `/blocks/head`(https://paritytech.github.io/substrate-api-sidecar/dist/){target=_blank} for the latest finalized block, and then decodes the block for the the `from`, `to`, `value`, `tx hash` and `transaction status` of native token transfers at both the EVM and Substrate API level. 
 
 --8<-- 'code/vs-ethereum/sidecar-transfer.md'
 

--- a/builders/get-started/eth-compare/transfers-api.md
+++ b/builders/get-started/eth-compare/transfers-api.md
@@ -41,7 +41,9 @@ The different transfer scenarios are:
 
 All the scenarios described above will effectively transfer base layer network tokens. The easiest way to monitor them all is to rely on the `balances.Transfer` event.
 
-## Monitor All Balance Transfers with the Substrate API {: #monitor-transfers }
+## Monitor Native Token Balance Transfers {: #monitor-transfers }
+
+### Using Polkadot.js API {: #using-polkadotjs-api }
 
 The [Polkadot.js API package](https://polkadot.js.org/docs/api/start){target=_blank} provides developers a way to interact with Substrate chains using JavaScript.
 
@@ -50,3 +52,16 @@ The following code snippet uses [`subscribeFinalizedHeads`](https://polkadot.js.
 --8<-- 'code/vs-ethereum/balance-event.md'
 
 In addition, you can find more sample code snippets related to more specific cases around balance transfers at this [GitHub page](https://gist.github.com/crystalin/b2ce44a208af60d62b5ecd1bad513bce){target=_blank}.
+
+### Using Substrate API Sidecar {: #using-substrate-api-sidecar }
+
+Developers can also retrieve Moonbeam blocks and monitor transactions using [Substrate API Sidecar](https://github.com/paritytech/substrate-api-sidecar){target=_blank}, a REST API service for interacting with blockchains built with the Substrate framework. 
+
+The following code snippet uses the Axios HTTP client to query the Sidecar endpoint `/blocks/head`(https://paritytech.github.io/substrate-api-sidecar/dist/){target=_blank} for the latest finalized block, and then decodes the block for the the `from`, `to`, `amount`, `tx hash` and `transaction status` of native token transfers at both the EVM and Substrate API level. 
+
+--8<-- 'code/vs-ethereum/sidecar-transfer.md'
+
+You can reference the [Substrate API Sidecar page](/builders/build/substrate-api/sidecar/) for information on installing and running your own Sidecar service instance, as well as more details on how to decode Sidecar blocks for Moonbeam transaction related information. 
+
+
+


### PR DESCRIPTION
### Description

Adds a code snippet example for retrieving and decoding Sidecar blocks for native token transfers to the Transfer API page, and links to the section from the Sidecar page. 

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [x] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
