### PR TITLE
call permit and randomness support for Moonbeam and Moonriver

### DIFF
--- a/builders/build/canonical-contracts.md
+++ b/builders/build/canonical-contracts.md
@@ -91,6 +91,8 @@ There are a set of precompiled contracts included on Moonbeam, Moonriver, and Mo
     |  [XCM Transactor](https://github.com/PureStake/moonbeam/blob/master/precompiles/xcm-transactor/src/v1/XcmTransactorV1.sol){target=_blank}  | {{networks.moonbeam.precompiles.xcm_transactor_legacy}} |
     |  [Author Mapping](https://github.com/PureStake/moonbeam/blob/master/precompiles/author-mapping/AuthorMappingInterface.sol){target=_blank}  |    {{networks.moonbeam.precompiles.author_mapping}}     |
     |                   [Batch](https://github.com/PureStake/moonbeam/blob/master/precompiles/batch/Batch.sol){target=_blank}                    |         {{networks.moonbeam.precompiles.batch}}         |
+    |            [Randomness](https://github.com/PureStake/moonbeam/blob/master/precompiles/randomness/Randomness.sol){target=_blank}            |      {{networks.moonbeam.precompiles.randomness}}       |
+    |           [Call Permit](https://github.com/PureStake/moonbeam/blob/master/precompiles/call-permit/CallPermit.sol){target=_blank}           |     {{networks.moonbeam.precompiles.call_permit }}      |
 
 === "Moonriver"
     |                                                                  Contract                                                                  |                         Address                          |
@@ -104,6 +106,8 @@ There are a set of precompiled contracts included on Moonbeam, Moonriver, and Mo
     |  [XCM Transactor](https://github.com/PureStake/moonbeam/blob/master/precompiles/xcm-transactor/src/v1/XcmTransactorV1.sol){target=_blank}  | {{networks.moonriver.precompiles.xcm_transactor_legacy}} |
     |  [Author Mapping](https://github.com/PureStake/moonbeam/blob/master/precompiles/author-mapping/AuthorMappingInterface.sol){target=_blank}  |    {{networks.moonriver.precompiles.author_mapping}}     |
     |                   [Batch](https://github.com/PureStake/moonbeam/blob/master/precompiles/batch/Batch.sol){target=_blank}                    |         {{networks.moonriver.precompiles.batch}}         |
+    |            [Randomness](https://github.com/PureStake/moonbeam/blob/master/precompiles/randomness/Randomness.sol){target=_blank}            |      {{networks.moonriver.precompiles.randomness}}       |
+    |           [Call Permit](https://github.com/PureStake/moonbeam/blob/master/precompiles/call-permit/CallPermit.sol){target=_blank}           |     {{networks.moonriver.precompiles.call_permit }}      |
 
 === "Moonbase Alpha"
     |                                                                    Contract                                                                     |                         Address                         |

--- a/builders/pallets-precompiles/precompiles/call-permit.md
+++ b/builders/pallets-precompiles/precompiles/call-permit.md
@@ -16,7 +16,17 @@ When the call permit is dispatched, it is done so on behalf of the user who sign
 
 For example, Alice signs a call permit and Bob dispatches it and performs the call on behalf of Alice. Bob pays for the transaction fees and as such, Alice doesn't need to have any of the native currency to pay for the transaction, unless the call includes a transfer. 
 
-The call permit precompile is currently only available on Moonbase Alpha and is located at the following address:
+The call permit precompile is located at the following address:
+
+=== "Moonbeam"
+     ```
+     {{networks.moonbeam.precompiles.call_permit }}
+     ```
+
+=== "Moonriver"
+     ```
+     {{networks.moonriver.precompiles.call_permit }}
+     ```
 
 === "Moonbase Alpha"
      ```

--- a/builders/pallets-precompiles/precompiles/randomness.md
+++ b/builders/pallets-precompiles/precompiles/randomness.md
@@ -72,10 +72,26 @@ Where the inputs that need to be provided can be defined as:
 
 The interface includes the following constants:
 
-- **MAX_RANDOM_WORDS** - the maximum number of random words being requested 
-- **MIN_VRF_BLOCKS_DELAY** - the minimum number of blocks before a request can be fulfilled for local VRF requests
-- **MAX_VRF_BLOCKS_DELAY** - the maximum number of blocks before a request can be fulfilled for local VRF requests
-- **REQUEST_DEPOSIT_AMOUNT** - the deposit amount needed to request random words. There is one deposit per request
+- **maxRandomWords** - the maximum number of random words being requested 
+- **minBlockDelay** - the minimum number of blocks before a request can be fulfilled for local VRF requests
+- **maxBlockDelay** - the maximum number of blocks before a request can be fulfilled for local VRF requests
+- **deposit** - the deposit amount needed to request random words. There is one deposit per request
+
+=== "Moonbeam"
+    |        Variable        |                             Value                              |
+    |:----------------------:|:--------------------------------------------------------------:|
+    |    MAX_RANDOM_WORDS    |   {{ networks.moonbeam.randomness.max_random_words }} words    |
+    |  MIN_VRF_BLOCKS_DELAY  | {{ networks.moonbeam.randomness.min_vrf_blocks_delay }} blocks |
+    |  MAX_VRF_BLOCKS_DELAY  | {{ networks.moonbeam.randomness.max_vrf_blocks_delay }} blocks |
+    | REQUEST_DEPOSIT_AMOUNT | {{ networks.moonbeam.randomness.req_deposit_amount.dev }} GLMR |
+
+=== "Moonriver"
+    |        Variable        |                             Value                              |
+    |:----------------------:|:--------------------------------------------------------------:|
+    |    MAX_RANDOM_WORDS    |   {{ networks.moonriver.randomness.max_random_words }} words    |
+    |  MIN_VRF_BLOCKS_DELAY  | {{ networks.moonriver.randomness.min_vrf_blocks_delay }} blocks |
+    |  MAX_VRF_BLOCKS_DELAY  | {{ networks.moonriver.randomness.max_vrf_blocks_delay }} blocks |
+    | REQUEST_DEPOSIT_AMOUNT | {{ networks.moonriver.randomness.req_deposit_amount.dev }} MOVR |
 
 === "Moonbase Alpha"
     |        Variable        |                             Value                              |

--- a/builders/pallets-precompiles/precompiles/randomness.md
+++ b/builders/pallets-precompiles/precompiles/randomness.md
@@ -20,7 +20,17 @@ Moonbeam provides a randomness precompile, which is a Solidity interface that en
 
 This guide will show you how to use the randomness precompile and randomness consumer contract to create a lottery where the winners will randomly be selected. You'll also learn how to interact with the randomness precompile directly to perform actions such as purging an expired randomness request.
 
-The randomness precompile is currently only available on Moonbase Alpha and is located at the following address:
+The randomness precompile is located at the following address:
+
+=== "Moonbeam"
+     ```
+     {{ networks.moonbeam.precompiles.randomness }}
+     ```
+
+=== "Moonriver"
+     ```
+     {{ networks.moonriver.precompiles.randomness }}
+     ```
 
 === "Moonbase Alpha"
      ```

--- a/learn/features/randomness.md
+++ b/learn/features/randomness.md
@@ -30,10 +30,33 @@ You can interact with and request on-chain randomness using the randomness preco
 
 ## Quick Reference {: #quick-reference }
 
+=== "Moonbeam"
+    |        Variable         |                                             Value                                             |
+    |:-----------------------:|:---------------------------------------------------------------------------------------------:|
+    |         Deposit         |                {{ networks.moonbeam.randomness.req_deposit_amount.dev }} GLMR                 |
+    | Block expiration delay  |                  {{ networks.moonbeam.randomness.block_expiration }} blocks                   |
+    | Epoch expiration delay  |                  {{ networks.moonbeam.randomness.epoch_expiration }} epochs                   |
+    |   Minimum block delay   |                {{ networks.moonbeam.randomness.min_vrf_blocks_delay }} blocks                 |
+    |   Maximum block delay   |                {{ networks.moonbeam.randomness.max_vrf_blocks_delay }} blocks                 |
+    |  Maximum random words   |                   {{ networks.moonbeam.randomness.max_random_words }} words                   |
+    | Epoch fulfillment delay | {{ networks.moonbeam.randomness.epoch_fulfillment_delay }} epochs (following the current one) |
+
+
+=== "Moonriver"
+    |        Variable         |                                             Value                                              |
+    |:-----------------------:|:----------------------------------------------------------------------------------------------:|
+    |         Deposit         |                {{ networks.moonriver.randomness.req_deposit_amount.dev }} MOVR                 |
+    | Block expiration delay  |                  {{ networks.moonriver.randomness.block_expiration }} blocks                   |
+    | Epoch expiration delay  |                  {{ networks.moonriver.randomness.epoch_expiration }} epochs                   |
+    |   Minimum block delay   |                {{ networks.moonriver.randomness.min_vrf_blocks_delay }} blocks                 |
+    |   Maximum block delay   |                {{ networks.moonriver.randomness.max_vrf_blocks_delay }} blocks                 |
+    |  Maximum random words   |                   {{ networks.moonriver.randomness.max_random_words }} words                   |
+    | Epoch fulfillment delay | {{ networks.moonriver.randomness.epoch_fulfillment_delay }} epochs (following the current one) |
+
 === "Moonbase Alpha"
     |        Variable         |                                             Value                                             |
     |:-----------------------:|:---------------------------------------------------------------------------------------------:|
-    |         Deposit         |                   {{ networks.moonbase.randomness.req_deposit_amount.dev }} DEV                   |
+    |         Deposit         |                 {{ networks.moonbase.randomness.req_deposit_amount.dev }} DEV                 |
     | Block expiration delay  |                  {{ networks.moonbase.randomness.block_expiration }} blocks                   |
     | Epoch expiration delay  |                  {{ networks.moonbase.randomness.epoch_expiration }} epochs                   |
     |   Minimum block delay   |                {{ networks.moonbase.randomness.min_vrf_blocks_delay }} blocks                 |

--- a/learn/features/randomness.md
+++ b/learn/features/randomness.md
@@ -41,7 +41,6 @@ You can interact with and request on-chain randomness using the randomness preco
     |  Maximum random words   |                   {{ networks.moonbeam.randomness.max_random_words }} words                   |
     | Epoch fulfillment delay | {{ networks.moonbeam.randomness.epoch_fulfillment_delay }} epochs (following the current one) |
 
-
 === "Moonriver"
     |        Variable         |                                             Value                                              |
     |:-----------------------:|:----------------------------------------------------------------------------------------------:|

--- a/learn/features/randomness.md
+++ b/learn/features/randomness.md
@@ -33,7 +33,7 @@ You can interact with and request on-chain randomness using the randomness preco
 === "Moonbeam"
     |        Variable         |                                             Value                                             |
     |:-----------------------:|:---------------------------------------------------------------------------------------------:|
-    |         Deposit         |                {{ networks.moonbeam.randomness.req_deposit_amount.dev }} GLMR                 |
+    |         Deposit         |                {{ networks.moonbeam.randomness.req_deposit_amount.glmr }} GLMR                 |
     | Block expiration delay  |                  {{ networks.moonbeam.randomness.block_expiration }} blocks                   |
     | Epoch expiration delay  |                  {{ networks.moonbeam.randomness.epoch_expiration }} epochs                   |
     |   Minimum block delay   |                {{ networks.moonbeam.randomness.min_vrf_blocks_delay }} blocks                 |
@@ -44,7 +44,7 @@ You can interact with and request on-chain randomness using the randomness preco
 === "Moonriver"
     |        Variable         |                                             Value                                              |
     |:-----------------------:|:----------------------------------------------------------------------------------------------:|
-    |         Deposit         |                {{ networks.moonriver.randomness.req_deposit_amount.dev }} MOVR                 |
+    |         Deposit         |                {{ networks.moonriver.randomness.req_deposit_amount.movr }} MOVR                 |
     | Block expiration delay  |                  {{ networks.moonriver.randomness.block_expiration }} blocks                   |
     | Epoch expiration delay  |                  {{ networks.moonriver.randomness.epoch_expiration }} epochs                   |
     |   Minimum block delay   |                {{ networks.moonriver.randomness.min_vrf_blocks_delay }} blocks                 |

--- a/variables.yml
+++ b/variables.yml
@@ -390,6 +390,16 @@ networks:
           usdt_usd: '0xF80DAd54AF79257D41c30014160349896ca5370a'
           xrp_usd: '0x3FD363679fb59596d45881bbfBe4bb864f3545A2'
           yfi_usd: '0xE3324ea60FA272BBB4511dDBD4776feFE4674fa0'
+    randomness:
+      max_random_words: 100
+      min_vrf_blocks_delay: 2
+      max_vrf_blocks_delay: 2000
+      req_deposit_amount:
+        movr: 1
+        wei: 1000000000000000000
+      block_expiration: 10000
+      epoch_expiration: 10000
+      epoch_fulfillment_delay: 2
     substrate_api_sidecar:
       stable_version: 11.3.3
     tx_weight_to_gas_ratio: 25000
@@ -556,6 +566,16 @@ networks:
           glmr_usd: '0x4497B606be93e773bbA5eaCFCb2ac5E2214220Eb'
           link_usd: '0xd61D7398B7734aBe7C4B143fE57dC666D2fe83aD'
           usdc_usd: '0xA122591F60115D63421f66F752EF9f6e0bc73abC'
+    randomness:
+      max_random_words: 100
+      min_vrf_blocks_delay: 2
+      max_vrf_blocks_delay: 2000
+      req_deposit_amount:
+        glmr: 1
+        wei: 1000000000000000000
+      block_expiration: 10000
+      epoch_expiration: 10000
+      epoch_fulfillment_delay: 2
     substrate_api_sidecar:
       stable_version: 11.3.3
       tx_weight_to_gas_ratio: 25000


### PR DESCRIPTION
### Description

Adds support for CallPermit and Randomness precompiles in Moonbeam and Moonriver. 

Goes with CN PR: 
https://github.com/PureStake/moonbeam-docs-cn/pull/154