### PR TITLE
add treasury council to docs

### DIFF
--- a/learn/features/treasury.md
+++ b/learn/features/treasury.md
@@ -9,7 +9,7 @@ description: As a Polkadot parachain, Moonbeam has an on-chain treasury controll
 
 ## Introduction {: #introduction } 
 
-A treasury is an on-chain managed collection of funds. Moonbeam will have a community treasury for supporting network initiatives to further the network. This treasury will be funded by a percentage of transaction fees of the network and will be managed by the Council.
+A treasury is an on-chain managed collection of funds. Moonbeam will have a community treasury for supporting network initiatives to further the network. This treasury will be funded by a percentage of transaction fees of the network and will be managed by the treasury council.
 
 Each Moonbeam-based network will have it's own treasury. In other words, the Moonbase Alpha TestNet, Moonshadow on Westend, Moonriver on Kusama, and Moonbeam on Polkadot will each have their own respective treasury. 
 
@@ -17,55 +17,62 @@ Each Moonbeam-based network will have it's own treasury. In other words, the Moo
 
 Some important terminology to understand in regards to treasuries:
 
-- **Council** — a group of elected individuals that control how treasury funds will be spent
-- **Proposal** — a plan or suggestion to further the network that is put forth by stakeholders to be approved by the council
+- **Treasury council** — a group of elected individuals that control how treasury funds will be spent
+- **Proposal** — a plan or suggestion to further the network that is put forth by stakeholders to be approved by the treasury council
 - **Proposal bond** — a deposit equal to a percentage of the total proposal spend amount
 - **Proposal bond minimum** — minimum amount for a proposal bond. This is the lower limit of the bond for a treasury proposal
 - **Proposal bond maximum** — maximum amount (cap) for a proposal bond. **Proposal bonds are currently uncapped in all Moonbeam-based networks**
+- **Motion duration** - the maximum amount of time, in blocks, for treasury council members to vote on motions. Motions may end in fewer blocks if enough votes are cast to determine the result
 - **Spend period** — the amount of days, in blocks, during which the treasury funds as many proposals as possible without exceeding the maximum
 - **Maximum approved proposals** — the maximum amount of proposals that can wait in the spending queue
 
 === "Moonbeam"
-    |            Variable             |  |                                                        Value                                                         |
-    |:-------------------------------:|::|:--------------------------------------------------------------------------------------------------------------------:|
-    |          Proposal bond          |  |                        {{ networks.moonbeam.treasury.proposal_bond }}% of the proposed spend                         |
-    |      Proposal bond minimum      |  |                               {{ networks.moonbeam.treasury.proposal_bond_min }} GLMR                                |
-    |      Proposal bond maximum      |  |                                  {{ networks.moonbeam.treasury.proposal_bond_max }}                                  |
-    |          Spend period           |  | {{ networks.moonbeam.treasury.spend_period_blocks }} blocks ({{ networks.moonbeam.treasury.spend_period_days}} days) |
-    |   Maximum approved proposals    |  |                               {{ networks.moonbeam.treasury.max_approved_proposals }}                                |
-    | % of transaction fees allocated |  |                                  {{ networks.moonbeam.treasury.tx_fees_allocated }}                                  |
+    |             Variable             |                                                            Value                                                            |
+    |:--------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|
+    | Maximum treasury council members |                                {{ networks.moonbeam.treasury.council.max_members }} members                                 |
+    |          Proposal bond           |                            {{ networks.moonbeam.treasury.proposal_bond }}% of the proposed spend                            |
+    |      Proposal bond minimum       |                                   {{ networks.moonbeam.treasury.proposal_bond_min }} GLMR                                   |
+    |      Proposal bond maximum       |                                     {{ networks.moonbeam.treasury.proposal_bond_max }}                                      |
+    |         Motion duration          | {{ networks.moonbeam.treasury.motion_duration_blocks }} blocks ({{ networks.moonbeam.treasury.motion_duration_days }} days) |
+    |           Spend period           |    {{ networks.moonbeam.treasury.spend_period_blocks }} blocks ({{ networks.moonbeam.treasury.spend_period_days}} days)     |
+    |    Maximum approved proposals    |                                   {{ networks.moonbeam.treasury.max_approved_proposals }}                                   |
+    | % of transaction fees allocated  |                                     {{ networks.moonbeam.treasury.tx_fees_allocated }}                                      |
 
 === "Moonriver"
-    |            Variable             |  |                                                         Value                                                          |
-    |:-------------------------------:|::|:----------------------------------------------------------------------------------------------------------------------:|
-    |          Proposal bond          |  |                         {{ networks.moonriver.treasury.proposal_bond }}% of the proposed spend                         |
-    |      Proposal bond minimum      |  |                                {{ networks.moonriver.treasury.proposal_bond_min }} MOVR                                |
-    |      Proposal bond maximum      |  |                                  {{ networks.moonriver.treasury.proposal_bond_max }}                                   |
-    |          Spend period           |  | {{ networks.moonriver.treasury.spend_period_blocks }} blocks ({{ networks.moonriver.treasury.spend_period_days}} days) |
-    |   Maximum approved proposals    |  |                                {{ networks.moonriver.treasury.max_approved_proposals }}                                |
-    | % of transaction fees allocated |  |                                  {{ networks.moonriver.treasury.tx_fees_allocated }}                                   |
+    |             Variable             |                                                             Value                                                             |
+    |:--------------------------------:|:-----------------------------------------------------------------------------------------------------------------------------:|
+    | Maximum treasury council members |                                 {{ networks.moonriver.treasury.council.max_members }} members                                 |
+    |          Proposal bond           |                            {{ networks.moonriver.treasury.proposal_bond }}% of the proposed spend                             |
+    |      Proposal bond minimum       |                                   {{ networks.moonriver.treasury.proposal_bond_min }} MOVR                                    |
+    |      Proposal bond maximum       |                                      {{ networks.moonriver.treasury.proposal_bond_max }}                                      |
+    |         Motion duration          | {{ networks.moonriver.treasury.motion_duration_blocks }} blocks ({{ networks.moonriver.treasury.motion_duration_days }} days) |
+    |           Spend period           |    {{ networks.moonriver.treasury.spend_period_blocks }} blocks ({{ networks.moonriver.treasury.spend_period_days}} days)     |
+    |    Maximum approved proposals    |                                   {{ networks.moonriver.treasury.max_approved_proposals }}                                    |
+    | % of transaction fees allocated  |                                      {{ networks.moonriver.treasury.tx_fees_allocated }}                                      |
 
 === "Moonbase Alpha"
-    |            Variable             |  |                                                        Value                                                         |
-    |:-------------------------------:|::|:--------------------------------------------------------------------------------------------------------------------:|
-    |          Proposal bond          |  |                        {{ networks.moonbase.treasury.proposal_bond }}% of the proposed spend                         |
-    |      Proposal bond minimum      |  |                                {{ networks.moonbase.treasury.proposal_bond_min }} DEV                                |
-    |      Proposal bond maximum      |  |                                  {{ networks.moonbase.treasury.proposal_bond_max }}                                  |
-    |          Spend period           |  | {{ networks.moonbase.treasury.spend_period_blocks }} blocks ({{ networks.moonbase.treasury.spend_period_days}} days) |
-    |   Maximum approved proposals    |  |                               {{ networks.moonbase.treasury.max_approved_proposals }}                                |
-    | % of transaction fees allocated |  |                                  {{ networks.moonbase.treasury.tx_fees_allocated }}                                  |
+    |             Variable             |                                                            Value                                                            |
+    |:--------------------------------:|:---------------------------------------------------------------------------------------------------------------------------:|
+    | Maximum treasury council members |                                {{ networks.moonbase.treasury.council.max_members }} members                                 |
+    |          Proposal bond           |                            {{ networks.moonbase.treasury.proposal_bond }}% of the proposed spend                            |
+    |      Proposal bond minimum       |                                   {{ networks.moonbase.treasury.proposal_bond_min }} DEV                                    |
+    |      Proposal bond maximum       |                                     {{ networks.moonbase.treasury.proposal_bond_max }}                                      |
+    |         Motion duration          | {{ networks.moonbase.treasury.motion_duration_blocks }} blocks ({{ networks.moonbase.treasury.motion_duration_days }} days) |
+    |           Spend period           |    {{ networks.moonbase.treasury.spend_period_blocks }} blocks ({{ networks.moonbase.treasury.spend_period_days}} days)     |
+    |    Maximum approved proposals    |                                   {{ networks.moonbase.treasury.max_approved_proposals }}                                   |
+    | % of transaction fees allocated  |                                     {{ networks.moonbase.treasury.tx_fees_allocated }}                                      |
 
 ## Community Treasury {: #community-treasury } 
 
-The Treasury is funded by a percentage of each block's transaction fees. The remaining percentage of the fees is burned (check the table above). The Treasury allows stakeholders to submit spending proposals to be reviewed and voted on by the Council. These spending proposals should include initiatives to further the network or boost network engagement. Some network initiatives could include funding integrations or collaborations, community events, network outreach, and more. 
+The treasury is funded by a percentage of each block's transaction fees. The remaining percentage of the fees is burned (check the table above). The treasury allows stakeholders to submit spending proposals to be reviewed and voted on by the treasury council. These spending proposals should include initiatives to further the network or boost network engagement. Some network initiatives could include funding integrations or collaborations, community events, network outreach, and more. 
 
 To deter spam, proposals must be submitted with a deposit, also known as a proposal bond. The proposal bond is a percentage (check the table above) of the amount requested by the proposer, with a minimum amount and no upper limit (compared to Polkadot and Kusama, which have a maximum bond amount). A governance proposal can change these values. So, any token holder with enough tokens to cover the deposit can submit a proposal. If the proposer doesn't have enough funds to cover the deposit, the extrinsic will fail due to insufficient funds, but transaction fees will still be deducted. 
 
-Once a proposal has been submitted, the Council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the Council. On the other hand, the threshold for rejecting a proposal is at least one-half of the Council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted.
+Once a proposal has been submitted, the treasury council votes on it. The threshold for accepting a treasury proposal is at least three-fifths of the treasury council. On the other hand, the threshold for rejecting a proposal is at least one-half of the treasury council. Please note that there is no way for a user to revoke a treasury proposal after it has been submitted.
  
-If approved by the council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low. If the proposal gets rejected, the deposit will be lost and transferred to the parachain treasury account.
+If approved by the treasury council, the proposal enters a queue to be placed into a spend period. If the spending queue happens to contain the number of maximum approved proposals, the proposal submission will fail similarly to how it would if the proposer's balance is too low. If the proposal gets rejected, the deposit will be lost and transferred to the parachain treasury account.
 
-Once the proposal is in a spend period, the funds will get distributed to the beneficiary, and the original deposit will be returned to the proposer. If the Treasury runs out of funds, the remaining approved proposals will remain in storage until the following spend period when the Treasury has enough funds again.
+Once the proposal is in a spend period, the funds will get distributed to the beneficiary, and the original deposit will be returned to the proposer. If the treasury runs out of funds, the remaining approved proposals will remain in storage until the following spend period when the treasury has enough funds again.
 
 The happy path for a treasury proposal is shown in the following diagram:
 

--- a/variables.yml
+++ b/variables.yml
@@ -163,12 +163,15 @@ networks:
         address1: '0x4c5A56ed5A4FF7B09aA86560AfD7d383F4831Cce'
         address2: '0x623c9E50647a049F92090fe55e22cC0509872FB6'
     treasury:
+      council_max_members: 9
+      motion_duration_days: 3
+      motion_duration_blocks: 21600
       proposal_bond: 5
       proposal_bond_min: 1
       proposal_bond_max: uncapped
       spend_period_blocks: 43200
       spend_period_days: 6
-      max_approved_proposals: 100
+      max_approved_proposals: 20
       tx_fees_allocated: 20
       tx_fees_burned: 80
     proxy:
@@ -303,12 +306,15 @@ networks:
       max_del_per_can: 300
       max_del_per_del: 100
     treasury:
+      council_max_members: 9
+      motion_duration_days: 3
+      motion_duration_blocks: 21600
       proposal_bond: 5
       proposal_bond_min: 1
       proposal_bond_max: uncapped
       spend_period_blocks: 43200
       spend_period_days: 6
-      max_approved_proposals: 100
+      max_approved_proposals: 20
       tx_fees_allocated: 20
       tx_fees_burned: 80
     proxy:
@@ -494,12 +500,15 @@ networks:
       max_del_per_can: 300
       max_del_per_del: 100
     treasury:
+      council_max_members: 9
+      motion_duration_days: 3
+      motion_duration_blocks: 21600
       proposal_bond: 5
       proposal_bond_min: 100
       proposal_bond_max: uncapped
       spend_period_blocks: 43200
       spend_period_days: 6
-      max_approved_proposals: 100
+      max_approved_proposals: 20
       tx_fees_allocated: 20
       tx_fees_burned: 80
     proxy:


### PR DESCRIPTION
### Description

Updates the treasury docs to include configs for treasury council

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
