### PR TITLE
bump moonbeam to v0.26.0

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -9,7 +9,7 @@ title: Full Node Docker Commands for MacOS
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.25.0 \
+purestake/moonbeam:v0.26.0 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -28,7 +28,7 @@ purestake/moonbeam:v0.25.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.25.0 \
+purestake/moonbeam:v0.26.0 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \

--- a/variables.yml
+++ b/variables.yml
@@ -426,9 +426,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.25.0
-    parachain_sha256sum: a468d7f8fd834dda504d38138db8021573b0f0afbed3207957e773a6bf79072b
-    tracing_tag: purestake/moonbeam-tracing:v0.25.0-1701-e8cc
+    parachain_release_tag: v0.26.0
+    parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
+    tracing_tag: purestake/moonbeam-tracing:sha-363761cd-opt-1800-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     binary_name: moonbeam

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
     build_tag: v0.26.0
-    tracing_tag: purestake/moonbeam-tracing:sha-363761cd-opt-1800-latest
+    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
     rpc_url: http://127.0.0.1:9933
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -17,7 +17,7 @@ networks:
     block_explorer: https://moonbase.moonscan.io/
     parachain_release_tag: v0.26.0 # must be in this exact format for links to work
     parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:sha-363761cd-opt-1800-latest
+    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data
@@ -237,7 +237,7 @@ networks:
     node_directory: /var/lib/moonriver-data
     parachain_release_tag: v0.26.0
     parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:sha-363761cd-opt-1800-latest   
+    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest   
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam
@@ -428,7 +428,7 @@ networks:
     node_directory: /var/lib/moonbeam-data
     parachain_release_tag: v0.26.0
     parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:sha-363761cd-opt-1800-latest
+    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     binary_name: moonbeam


### PR DESCRIPTION
### Description

Bump Moonbeam to v0.26.0
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/164
