### PR TITLE
bump client version to v0.26.1

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -9,7 +9,7 @@ title: Full Node Docker Commands for MacOS
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -28,7 +28,7 @@ purestake/moonbeam:v0.26.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -47,7 +47,7 @@ purestake/moonbeam:v0.26.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -66,7 +66,7 @@ purestake/moonbeam:v0.26.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -86,7 +86,7 @@ purestake/moonbeam:v0.26.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \
@@ -105,7 +105,7 @@ purestake/moonbeam:v0.26.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.26.0 \
+purestake/moonbeam:v0.26.1 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.26.0
-    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
+    build_tag: v0.26.1
+    tracing_tag: purestake/moonbeam-tracing:v0.26.1-1802-latest
     rpc_url: http://127.0.0.1:9933
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -15,9 +15,9 @@ networks:
     hex_chain_id: '0x507'
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
-    parachain_release_tag: v0.26.0 # must be in this exact format for links to work
-    parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
+    parachain_release_tag: v0.26.1 # must be in this exact format for links to work
+    parachain_sha256sum: 16b17d45c8e492e1e4dd7fa2e113c7abfde473e33be1d9d0f0260a0d183470bc
+    tracing_tag: purestake/moonbeam-tracing:v0.26.1-1802-latest
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data
@@ -236,9 +236,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.26.0
-    parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest   
+    parachain_release_tag: v0.26.1
+    parachain_sha256sum: 16b17d45c8e492e1e4dd7fa2e113c7abfde473e33be1d9d0f0260a0d183470bc
+    tracing_tag: purestake/moonbeam-tracing:v0.26.1-1802-latest   
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam
@@ -428,9 +428,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.26.0
-    parachain_sha256sum: eff929c4ed6c5323cae16173eda048dcb647690c68ac06200d092e48de9b8655
-    tracing_tag: purestake/moonbeam-tracing:v0.26.0-1801-latest
+    parachain_release_tag: v0.26.1
+    parachain_sha256sum: 16b17d45c8e492e1e4dd7fa2e113c7abfde473e33be1d9d0f0260a0d183470bc
+    tracing_tag: purestake/moonbeam-tracing:v0.26.1-1802-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     binary_name: moonbeam


### PR DESCRIPTION
### Description

Bump the client version to v0.26.1 and update the tracing image
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/166