### PR TITLE
fix the index page meta description for xcm sdk

### DIFF
--- a/builders/xcm/xcm-sdk/index.md
+++ b/builders/xcm/xcm-sdk/index.md
@@ -1,6 +1,6 @@
 ---
-title: Cross-Chain Communication
-description: An overview of how cross-consensus messaging (XCM) works, and how developers can leverage polkadot/kusama XCM to transfer assets to and from Moonbeam.
+title: XCM SDK Guides
+description: Guides on the available methods and interfaces in the Moonbeam XCM SDK and how to use the XCM SDK to easily deposit and withdraw cross chain assets.
 template: main.html
 ---
 


### PR DESCRIPTION
### Description

There was leftover copy/pasta so this just updates the meta description for the XCM SDK index page.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a