### PR TITLE
update pruning flags

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -15,11 +15,10 @@ purestake/moonbeam:v0.26.1 \
 --name="YOUR-NODE-NAME" \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
+--state-pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```
 
@@ -35,11 +34,9 @@ purestake/moonbeam:v0.26.1 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```
 ## Moonriver Full Node {: #moonriver-full-node } 
@@ -53,11 +50,10 @@ purestake/moonbeam:v0.26.1 \
 --name="YOUR-NODE-NAME" \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
+--state-pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```
 
@@ -73,11 +69,9 @@ purestake/moonbeam:v0.26.1 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```
 
@@ -92,11 +86,10 @@ purestake/moonbeam:v0.26.1 \
 --name="YOUR-NODE-NAME" \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
+--state-pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```
 
@@ -112,10 +105,8 @@ purestake/moonbeam:v0.26.1 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---pruning archive \
 --state-cache-size 0 \
 -- \
 --execution wasm \
---pruning 1000 \
 --name="YOUR-NODE-NAME (Embedded Relay)"
 ```

--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -4,6 +4,8 @@ title: Full Node Docker Commands for MacOS
 
 # Code Snippets Collator/Full Node MacOS
 
+For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+
 ## Moonbeam Full Node {: #moonbeam-full-node } 
 
 ```

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -61,10 +61,15 @@ Next, make sure you set the ownership and permissions accordingly for the local 
     sudo chown -R $(id -u):$(id -g) {{ networks.moonbase.node_directory }}
     ```
 
-Now, execute the docker run command. If you are setting up a collator node, make sure to follow the code snippets for "Collator". Note that you have to:
+Now, execute the docker run command. If you are setting up a collator node, make sure to follow the code snippets for [Collator](#collator--collator). Note that you have to:
  
  - Replace `YOUR-NODE-NAME` in two different places
  - Replace `<50% RAM in MB>` for 50% of the actual RAM your server has. For example, for 32 GB RAM, the value must be set to `16000`. The minimum value is `2000`, but it is below the recommended specs
+
+If you're using MacOS, there are adapted [code snippets](https://www.github.com/PureStake/moonbeam-docs/blob/master/.snippets/text/full-node/macos-node.md){target=_blank} specific for MacOS which can be used instead.
+
+!!! note
+    For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
 
 ### Full Node {: #full-node } 
 
@@ -121,6 +126,9 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --execution wasm \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
+
+!!! note
+    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`. This is **not** recommended for Collators. 
 
 ### Collator {: #collator } 
 
@@ -179,20 +187,14 @@ Now, execute the docker run command. If you are setting up a collator node, make
     ```
 
 !!! note
-    For an overview of the above flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation.
-
-If you're using MacOS, there are adapted [code snippets](https://www.github.com/PureStake/moonbeam-docs/blob/master/.snippets/text/full-node/macos-node.md){target=_blank} specific for MacOS which can be used instead.
+    For an overview of the above flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation. 
 
 Once Docker pulls the necessary images, your full Moonbeam (or Moonriver) node will start, displaying lots of information, such as the chain specification, node name, role, genesis state, and more:
 
-![Full Node Starting](/images/node-operators/networks/run-a-node/docker/full-node-docker-1.png)
-
-!!! note
-    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`. This is **not** recommended for Collators.  
+![Full Node Starting](/images/node-operators/networks/run-a-node/docker/full-node-docker-1.png) 
 
 !!! note
     You can specify a custom Prometheus port with the `--prometheus-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
-
 
 ```
 docker run -p {{ networks.relay_chain.p2p }}:{{ networks.relay_chain.p2p }} -p {{ networks.parachain.p2p }}:{{ networks.parachain.p2p }} -p {{ networks.parachain.rpc }}:{{ networks.parachain.rpc }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} #rest of code goes here

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -78,12 +78,11 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --name="YOUR-NODE-NAME" \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -97,12 +96,11 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --name="YOUR-NODE-NAME" \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -116,12 +114,11 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --name="YOUR-NODE-NAME" \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -138,12 +135,10 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
@@ -158,12 +153,10 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
     
@@ -178,12 +171,10 @@ Now, execute the docker run command. If you are setting up a collator node, make
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -27,7 +27,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--wasm-execution`** - specifies the method for executing Wasm runtime code. The available options are:
     - **`compiled`** - this is the default and uses the [Wasmtime](https://github.com/paritytech/wasmtime){target=_blank} compiled runtime
     - **`interpreted-i-know-what-i-do`** - uses the [wasmi interpreter](https://github.com/paritytech/wasmi){target=_blank}
-- **`--state-pruning`** - specifies the state pruning mode. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
+- **`--state-pruning`** - specifies the state pruning mode. For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
     - **`archive`** - keeps the full state of all blocks
     - **`<number-of-blocks>`** - specifies a custom number of blocks to keep the state for
 - **`--state-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `0` to disable the cache and improve collator performance

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -27,7 +27,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--wasm-execution`** - specifies the method for executing Wasm runtime code. The available options are:
     - **`compiled`** - this is the default and uses the [Wasmtime](https://github.com/paritytech/wasmtime){target=_blank} compiled runtime
     - **`interpreted-i-know-what-i-do`** - uses the [wasmi interpreter](https://github.com/paritytech/wasmi){target=_blank}
-- **`--pruning`** - specifies the state pruning mode. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
+- **`--state-pruning`** - specifies the state pruning mode. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
     - **`archive`** - keeps the full state of all blocks
     - **`<number-of-blocks>`** - specifies a custom number of blocks to keep the state for
 - **`--state-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `0` to disable the cache and improve collator performance

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -212,7 +212,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
@@ -223,7 +223,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -251,7 +250,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
@@ -262,7 +261,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -290,7 +288,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
@@ -301,7 +299,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 
     [Install]
@@ -332,7 +329,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
@@ -343,7 +339,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -372,7 +367,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
@@ -383,7 +377,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -412,7 +405,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
@@ -423,7 +415,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 
     [Install]

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -181,13 +181,16 @@ The following commands will set up everything regarding running the service.
 
 ## Create the Configuration File {: #create-the-configuration-file }
 
-The next step is to create the systemd configuration file. If you are setting up a collator node, make sure to follow the code snippets for "Collator". Note that you have to:
+The next step is to create the systemd configuration file. If you are setting up a collator node, make sure to follow the code snippets for [Collator](#collator--collator). Note that you have to:
 
  - Replace `YOUR-NODE-NAME` in two different places
  - Replace `<50% RAM in MB>` for 50% of the actual RAM your server has. For example, for 32 GB RAM, the value must be set to `16000`. The minimum value is `2000`, but it is below the recommended specs
  - Double-check that the binary is in the proper path as described below (_ExecStart_)
  - Double-check the base path if you've used a different directory
  - Name the file `/etc/systemd/system/moonbeam.service`
+
+!!! note
+    For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
 
 ### Full Node {: #full-node } 
 
@@ -305,6 +308,9 @@ The next step is to create the systemd configuration file. If you are setting up
     WantedBy=multi-user.target
     ```
 
+!!! note
+    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports. More details are available by running `moonbeam --help`. This is **not** recommended for Collators. For an overview of the available flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation.
+
 ### Collator {: #collator } 
 
 === "Moonbeam"
@@ -420,9 +426,6 @@ The next step is to create the systemd configuration file. If you are setting up
     [Install]
     WantedBy=multi-user.target
     ```
-
-!!! note
-    If you want to run an RPC endpoint, to connect Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`. This is **not** recommended for Collators. For an overview of the above flags, please refer to the [Flags](/node-operators/networks/run-a-node/flags){target=_blank} page of our documentation.
 
 !!! note
     You can specify a custom Prometheus port with the `--prometheus-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -32,6 +32,9 @@ Spinning up a `debug`, `txpool`, or `tracing` node is similar to [running a full
   - **`--ethapi-trace-max-count <uint>`** — sets the maximum number of trace entries to be returned by the node. The default maximum number of trace entries a single request of `trace_filter` returns is `500`
   - **`-ethapi-trace-cache-duration <uint>`** — sets the duration (in seconds) after which the cache of `trace_filter,` for a given block, is discarded. The default amount of time blocks are stored in the cache is `300` seconds
 
+!!! note
+    If you want to run an RPC endpoint, to connect to Polkadot.js Apps, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`.  
+
 ## Run a Tracing Node with Docker {: #run-a-tracing-node-with-docker }
 
 If you haven't previously run a standard full Moonbeam node, you will need to setup a directory to store chain data:
@@ -82,10 +85,15 @@ Before getting started, you'll need to set the necessary permissions either for 
 
 Instead of the standard `purestake/moonbeam` docker image, you will need to use `purestake/moonbeam-tracing` image. The latest supported version can be found on the [Docker Hub for the `moonbeam-tracing` image](https://hub.docker.com/r/purestake/moonbeam-tracing/tags).
 
-The complete command for running a tracing node is as follows:
+Now, execute the docker run command. Note that you have to:
+ 
+ - Replace `YOUR-NODE-NAME` in two different places
+ - Replace `<50% RAM in MB>` for 50% of the actual RAM your server has. For example, for 32 GB RAM, the value must be set to `16000`. The minimum value is `2000`, but it is below the recommended specs
 
 !!! note
-    Make sure you replace `<50% RAM in MB>` for 50% of the actual RAM your server has. For example, for 32 GB RAM, the value must be set to `16000`. The minimum value is `2000`, but it is below the recommended specs
+    For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+
+The complete command for running a tracing node is as follows:
 
 === "Moonbeam"
     ```
@@ -94,7 +102,7 @@ The complete command for running a tracing node is as follows:
     {{ networks.moonbeam.tracing_tag }} \
     --base-path=/data \
     --chain {{ networks.moonbeam.chain_spec }} \
-    --name="Moonbeam-Tutorial" \
+    --name="YOUR-NODE-NAME" \
     --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
@@ -103,7 +111,7 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --name="Moonbeam-Tutorial (Embedded Relay)"
+    --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
 === "Moonriver"
@@ -113,7 +121,7 @@ The complete command for running a tracing node is as follows:
     {{ networks.moonriver.tracing_tag }} \
     --base-path=/data \
     --chain {{ networks.moonriver.chain_spec }} \
-    --name="Moonbeam-Tutorial" \
+    --name="YOUR-NODE-NAME" \
     --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
@@ -122,7 +130,7 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --name="Moonbeam-Tutorial (Embedded Relay)"
+    --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
 === "Moonbase Alpha"
@@ -132,7 +140,7 @@ The complete command for running a tracing node is as follows:
     {{ networks.moonbase.tracing_tag }} \
     --base-path=/data \
     --chain {{ networks.moonbase.chain_spec }} \
-    --name="Moonbeam-Tutorial" \
+    --name="YOUR-NODE-NAME" \
     --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
@@ -141,7 +149,7 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --name="Moonbeam-Tutorial (Embedded Relay)"
+    --name="YOUR-NODE-NAME (Embedded Relay)"
     ```
 
 === "Moonbeam Dev Node"
@@ -149,15 +157,12 @@ The complete command for running a tracing node is as follows:
     docker run --network="host" \
     -u $(id -u ${USER}):$(id -g ${USER}) \
     {{ networks.development.tracing_tag }} \
-    --name="Moonbeam-Tutorial" \
+    --name="YOUR-NODE-NAME" \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
     --runtime-cache-size 64 \
     --dev
     ```
-
-!!! note
-    If you want to run an RPC endpoint, to connect polkadot.js.org, or to run your own application, use the flags `--unsafe-rpc-external` and/or `--unsafe-ws-external` to run the full node with external access to the RPC ports.  More details are available by running `moonbeam --help`.  
 
 You should see a terminal log similar to the following if you spun up a Moonbase Alpha tracing node:
 
@@ -246,6 +251,9 @@ The next step is to create the systemd configuration file, you'll need to:
  - Double-check that the binary is in the proper path as described below (_ExecStart_)
  - Double-check the base path if you've used a different directory
  - Name the file `/etc/systemd/system/moonbeam.service`
+
+!!! note
+    For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
 
 === "Moonbeam"
     ```

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -95,7 +95,7 @@ The complete command for running a tracing node is as follows:
     --base-path=/data \
     --chain {{ networks.moonbeam.chain_spec }} \
     --name="Moonbeam-Tutorial" \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
@@ -103,7 +103,6 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="Moonbeam-Tutorial (Embedded Relay)"
     ```
 
@@ -115,7 +114,7 @@ The complete command for running a tracing node is as follows:
     --base-path=/data \
     --chain {{ networks.moonriver.chain_spec }} \
     --name="Moonbeam-Tutorial" \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
@@ -123,7 +122,6 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="Moonbeam-Tutorial (Embedded Relay)"
     ```
 
@@ -135,7 +133,7 @@ The complete command for running a tracing node is as follows:
     --base-path=/data \
     --chain {{ networks.moonbase.chain_spec }} \
     --name="Moonbeam-Tutorial" \
-    --pruning archive \
+    --state-pruning archive \
     --state-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
@@ -143,7 +141,6 @@ The complete command for running a tracing node is as follows:
     --runtime-cache-size 64 \
     -- \
     --execution wasm \
-    --pruning 1000 \
     --name="Moonbeam-Tutorial (Embedded Relay)"
     ```
 
@@ -270,7 +267,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
@@ -284,7 +281,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -311,7 +307,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
@@ -325,7 +321,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
     [Install]
@@ -352,7 +347,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
-         --pruning=archive \
+         --state-pruning=archive \
          --state-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
@@ -366,7 +361,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --pruning=1000 \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 
     [Install]


### PR DESCRIPTION
### Description

The pruning flag has been replaced with `--blocks-pruning` and `--state-pruning`. The default for `--blocks-pruning` is all blocks and the default for `--state-pruning` is the last 256 blocks.

This PR makes the following changes:

- Changes to collator flags:
  👉 we can use the default for `--state-pruning` and `--blocks-pruning`

- Changes to full nodes:
  👉 `--state-pruning` should be `archive` for the parachain flags and we can use the default for `--state-pruning` for the relay chain. We can also use the default for `--blocks-pruning`
  
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/177

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

https://github.com/PureStake/moonbeam-docs-cn/pull/177

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

N/A
