### PR TITLE
bump to v0.27.1 and rename state cache flag

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -18,7 +18,7 @@ purestake/moonbeam:v0.27.0 \
 --execution wasm \
 --wasm-execution compiled \
 --state-pruning archive \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -36,7 +36,7 @@ purestake/moonbeam:v0.27.0 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -53,7 +53,7 @@ purestake/moonbeam:v0.27.0 \
 --execution wasm \
 --wasm-execution compiled \
 --state-pruning archive \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -71,7 +71,7 @@ purestake/moonbeam:v0.27.0 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -89,7 +89,7 @@ purestake/moonbeam:v0.27.0 \
 --execution wasm \
 --wasm-execution compiled \
 --state-pruning archive \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -107,7 +107,7 @@ purestake/moonbeam:v0.27.0 \
 --validator \
 --execution wasm \
 --wasm-execution compiled \
---state-cache-size 0 \
+--trie-cache-size 0 \
 -- \
 --execution wasm \
 --name="YOUR-NODE-NAME (Embedded Relay)"

--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -11,7 +11,7 @@ For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pr
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -29,7 +29,7 @@ purestake/moonbeam:v0.27.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -46,7 +46,7 @@ purestake/moonbeam:v0.27.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -64,7 +64,7 @@ purestake/moonbeam:v0.27.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -82,7 +82,7 @@ purestake/moonbeam:v0.27.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \
@@ -100,7 +100,7 @@ purestake/moonbeam:v0.27.0 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.27.0 \
+purestake/moonbeam:v0.27.1 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -84,7 +84,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --execution wasm \
     --wasm-execution compiled \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -102,7 +102,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --execution wasm \
     --wasm-execution compiled \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -120,7 +120,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --execution wasm \
     --wasm-execution compiled \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -143,7 +143,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -161,7 +161,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \
@@ -179,7 +179,7 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
     --validator \
     --execution wasm \
     --wasm-execution compiled \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     -- \
     --execution wasm \

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -30,7 +30,7 @@ This guide will cover some of the most common flags and show you how to access a
 - **`--state-pruning`** - specifies the state pruning mode. For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`. If running a node with the `--validator` flag, the default is to keep the full state of all blocks. Otherwise, the state is only kept for the last 256 blocks. The available options are:
     - **`archive`** - keeps the full state of all blocks
     - **`<number-of-blocks>`** - specifies a custom number of blocks to keep the state for
-- **`--state-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `0` to disable the cache and improve collator performance
+- **`--trie-cache-size`** - specifies the size of the internal state cache. The default is `67108864`. You can set this value to `0` to disable the cache and improve collator performance. For client versions prior to v0.27.0, the `--trie-cache-size` flag was named `--state-cache-size`
 - **`--db-cache`** - specifies the memory the database cache is limited to use. It is recommended to set it to 50% of the actual RAM your server has. For example, for 32 GB RAM, the value should be set to `16000`. The minimum value is `2000`, but it is below the recommended specs 
 - **`--base-path`** - specifies the base path where your chain data is stored
 - **`--chain`** - specifies the chain specification to use. It can be a predefined chainspec such as `{{ networks.moonbeam.chain_spec }}`, `{{ networks.moonriver.chain_spec }}`, or `{{ networks.moonbase.chain_spec }}`. Or it can be a path to a file with the chainspec (such as the one exported by the `build-spec` command)

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -216,7 +216,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
@@ -254,7 +254,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
@@ -292,7 +292,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \
@@ -335,7 +335,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
@@ -373,7 +373,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
@@ -411,7 +411,7 @@ The next step is to create the systemd configuration file. If you are setting up
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -104,7 +104,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonbeam.chain_spec }} \
     --name="YOUR-NODE-NAME" \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbeam-substitutes-tracing \
@@ -123,7 +123,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonriver.chain_spec }} \
     --name="YOUR-NODE-NAME" \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonriver-substitutes-tracing \
@@ -142,7 +142,7 @@ The complete command for running a tracing node is as follows:
     --chain {{ networks.moonbase.chain_spec }} \
     --name="YOUR-NODE-NAME" \
     --state-pruning archive \
-    --state-cache-size 0 \
+    --trie-cache-size 0 \
     --db-cache <50% RAM in MB> \
     --ethapi=debug,trace,txpool \
     --wasm-runtime-overrides=/moonbeam/moonbase-substitutes-tracing \
@@ -276,7 +276,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --ethapi=debug,trace,txpool \
@@ -316,7 +316,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --ethapi=debug,trace,txpool \
@@ -356,7 +356,7 @@ The next step is to create the systemd configuration file, you'll need to:
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
-         --state-cache-size 0 \
+         --trie-cache-size 0 \
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --ethapi=debug,trace,txpool \

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.27.0
-    tracing_tag: purestake/moonbeam-tracing:v0.27.0-1900-latest
+    build_tag: v0.27.1
+    tracing_tag: purestake/moonbeam-tracing:v0.27.1-1901-latest
     rpc_url: http://127.0.0.1:9933
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -15,9 +15,9 @@ networks:
     hex_chain_id: '0x507'
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
-    parachain_release_tag: v0.27.0 # must be in this exact format for links to work
-    parachain_sha256sum: a02aaf673484c6c8fca4b000c6ee11b6c01778db86f84517926499d58673f200
-    tracing_tag: purestake/moonbeam-tracing:v0.27.0-1900-latest
+    parachain_release_tag: v0.27.1 # must be in this exact format for links to work
+    parachain_sha256sum: b497f3e9f6f9c1e8591fbcbde5c18e24a5a5b4cdb98bc641ac7e643890a523fe
+    tracing_tag: purestake/moonbeam-tracing:v0.27.1-1901-latest
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data
@@ -243,9 +243,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.27.0
-    parachain_sha256sum: a02aaf673484c6c8fca4b000c6ee11b6c01778db86f84517926499d58673f200
-    tracing_tag: purestake/moonbeam-tracing:v0.27.0-1900-latest   
+    parachain_release_tag: v0.27.1
+    parachain_sha256sum: b497f3e9f6f9c1e8591fbcbde5c18e24a5a5b4cdb98bc641ac7e643890a523fe
+    tracing_tag: purestake/moonbeam-tracing:v0.27.1-1901-latest   
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam
@@ -442,9 +442,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.27.0
-    parachain_sha256sum: a02aaf673484c6c8fca4b000c6ee11b6c01778db86f84517926499d58673f200
-    tracing_tag: purestake/moonbeam-tracing:v0.27.0-1900-latest
+    parachain_release_tag: v0.27.1
+    parachain_sha256sum: b497f3e9f6f9c1e8591fbcbde5c18e24a5a5b4cdb98bc641ac7e643890a523fe
+    tracing_tag: purestake/moonbeam-tracing:v0.27.1-1901-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     binary_name: moonbeam


### PR DESCRIPTION
### Description

As of client v0.27.0, the `--state-cache-size` flag was renamed to `--trie-cache-size`. This PR makes the changes where needed.

It also bumps the client version to v0.27.1

Related CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/179
Resolves #452 
