### PR TITLE
Updates benchmarked XCM instructions for Moonbase

### DIFF
--- a/builders/xcm/fees.md
+++ b/builders/xcm/fees.md
@@ -204,7 +204,7 @@ As an example, you can calculate the total cost of KSMs for sending an XCM messa
 
 Substrate has introduced a weight system that determines how heavy or, in other words, how expensive an extrinsic is from a computational cost perspective. One unit of weight is defined as one picosecond of execution time. When it comes to paying fees, users will pay a transaction fee based on the weight of the call that is being made, and each parachain can decide how to convert from weight to fee, for example, accounting for additional costs for transaction size, and storage costs.
 
-Both Moonbeam and Moonrive use a fixed amount of weight for each XCM instruction. However, Moonbase Alpha (TestNet) has the generic XCM instructions benchmarked, while the fungible XCM instructions still use a fixed amount of weight per instruction. As a consequence, the total weight cost of the benchmarked XCM instructions take into consideration the number of databse read/writes in addition to the weight required for a given instruction. The breakdown of weight cost for the database operations is as follows:
+Both Moonbeam and Moonriver use a fixed amount of weight for each XCM instruction. However, Moonbase Alpha (TestNet) has the generic XCM instructions benchmarked, while the fungible XCM instructions still use a fixed amount of weight per instruction. Consequently, the total weight cost of the benchmarked XCM instructions considers the number of database reads/writes in addition to the weight required for a given instruction. The breakdown of weight cost for the database operations is as follows:
 
 |     Database      |                    Read                     |                    Write                     |
 |:-----------------:|:-------------------------------------------:|:--------------------------------------------:|
@@ -214,7 +214,7 @@ Now that you know the weight costs for database reads and writes for Moonbase Al
 
 For example, the `WithdrawAsset` instruction is part of the fungible XCM instructions set. Therefore, it is not benchmarked, and the total weight cost of the `WithdrawAsset` instruction is `{{ networks.moonbase.xcm.instructions.weight_units.display }}`.
 
-The [`BuyExecution` instruction](https://github.com/PureStake/moonbeam/blob/master/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L220){target=_blank} has a base weight of `{{ networks.moonbase.xcm.instructions.buy_exec.base_weight }}`, and performs 4 database reads (`assetManager` pallet to get the `unitsPerSecond`). Therefore, the total weight cost of the `BuyExecution` instruction is calculated as:
+The [`BuyExecution` instruction](https://github.com/PureStake/moonbeam/blob/master/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L220){target=_blank} has a base weight of `{{ networks.moonbase.xcm.instructions.buy_exec.base_weight }}`, and performs four database reads (`assetManager` pallet to get the `unitsPerSecond`). Therefore, the total weight cost of the `BuyExecution` instruction is calculated as follows:
 
 ```
 {{ networks.moonbase.xcm.instructions.buy_exec.base_weight }} + 4*{{ networks.moonbase.db_weights.rocksdb_read }} = {{ networks.moonbase.xcm.instructions.buy_exec.total_weight }}

--- a/builders/xcm/fees.md
+++ b/builders/xcm/fees.md
@@ -77,10 +77,10 @@ As previously mentioned, Polkadot currently uses a [fixed amount of weight](http
 
 Although Polkadot doesn't currently use database weight units to calculate costs, the weight units for database operations, which have been benchmarked, are shared here for reference.
 
-|     Database      |                     Read                      |                     Write                      |
-|:-----------------:|:---------------------------------------------:|:----------------------------------------------:|
+|                                                                     Database                                                                     |                     Read                      |                     Write                      |
+|:------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------:|:----------------------------------------------:|
 | [RocksDB (default)](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}      | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
 
 With the instruction weight cost established, you can calculate the cost of each instruction in DOT. 
 
@@ -124,27 +124,27 @@ As an example, you can calculate the total cost of DOT for sending an XCM messag
 
 |  Instruction  |                         Weight                          |                           Cost                            |
 |:-------------:|:-------------------------------------------------------:|:---------------------------------------------------------:|
-| WithdrawAsset | {{ networks.polkadot.xcm_instructions.weight.display }}  |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT    |
-|  ClearOrigin  | {{ networks.polkadot.xcm_instructions.weight.display }}  |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT    |
-| BuyExecution  | {{ networks.polkadot.xcm_instructions.weight.display }}  |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT    |
-| DepositAsset  | {{ networks.polkadot.xcm_instructions.weight.display }}  |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT    |
+| WithdrawAsset | {{ networks.polkadot.xcm_instructions.weight.display }} |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT   |
+|  ClearOrigin  | {{ networks.polkadot.xcm_instructions.weight.display }} |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT   |
+| BuyExecution  | {{ networks.polkadot.xcm_instructions.weight.display }} |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT   |
+| DepositAsset  | {{ networks.polkadot.xcm_instructions.weight.display }} |   {{ networks.polkadot.xcm_instructions.dot_cost }} DOT   |
 |   **TOTAL**   | **{{ networks.polkadot.xcm_message.transfer.weight }}** | **{{ networks.polkadot.xcm_message.transfer.cost }} DOT** |
 
 ### Kusama {: #kusama }
 
 The total weight costs on Kusama take into consideration database reads and writes in addition to the weight required for a given instruction. Database read and write operations have not been benchmarked, while instruction weights have been. The breakdown of weight costs for the database operations is as follows:
 
-|     Database      |                    Read                     |                    Write                     |
-|:-----------------:|:-------------------------------------------:|:--------------------------------------------:|
+|                                                                    Database                                                                    |                    Read                     |                    Write                     |
+|:----------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------:|:--------------------------------------------:|
 | [RocksDB (default)](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.kusama.rocks_db.read_weight }}  | {{ networks.kusama.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/paritydb_weights.rs){target=_blank}      | {{ networks.kusama.parity_db.read_weight }} | {{ networks.kusama.parity_db.write_weight }} |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.kusama.parity_db.read_weight }} | {{ networks.kusama.parity_db.write_weight }} |
 
 Now that you are aware of the weight costs for database reads and writes on Kusama, you can calculate the weight cost for a given instruction using the base weight for an instruction. 
 
 For example, the [`WithdrawAsset` instruction](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs#L49-L53){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.withdraw.base_weight }}`, and performs one database read, and one database write. Therefore, the total weight cost of the `WithdrawAsset` instruction is calculated as:
 
 ```
-{{ networks.kusama.xcm_instructions.withdraw.base_weight }} + {{ networks.kusama.rocks_db.read_weight}} + {{ networks.kusama.rocks_db.write_weight}} = {{ networks.kusama.xcm_instructions.withdraw.total_weight }}
+{{ networks.kusama.xcm_instructions.withdraw.base_weight }} + {{ networks.kusama.rocks_db.read_weight}} + {{ networks.kusama.rocks_db.write_weight}} = {{ networks.kusama.xcm_instructions.withdraw.total_weight.display }}
 ```
 
 The [`BuyExecution` instruction](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs#L59-L61){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.buy_exec.base_weight }}` and doesn't include any database reads or writes. Therefore, the total weight cost of the `BuyExecution` instruction is `{{ networks.kusama.xcm_instructions.buy_exec.total_weight }}`.
@@ -183,7 +183,7 @@ XCM-KSM-Cost = XCM-Planck-KSM-Cost / KSMDecimalConversion
 Therefore, the actual calculation for the `WithdrawAsset` instruction is:
 
 ```
-XCM-Planck-KSM-Cost = {{ networks.kusama.xcm_instructions.withdraw.total_weight }} * {{ networks.kusama.xcm_instructions.planck_ksm_weight }} 
+XCM-Planck-KSM-Cost = {{ networks.kusama.xcm_instructions.withdraw.total_weight.numbers_only }} * {{ networks.kusama.xcm_instructions.planck_ksm_weight }} 
 XCM-KSM-Cost = {{ networks.kusama.xcm_instructions.withdraw.planck_ksm_cost }} / 10^12
 ```
 
@@ -191,13 +191,13 @@ The total cost for that particular instruction is `{{ networks.kusama.xcm_instru
 
 As an example, you can calculate the total cost of KSMs for sending an XCM message that transfers xcKSM to KSM on Kusama using the following weights and instruction costs:
 
-|  Instruction  |                              Weight                              |                               Cost                               |
-|:-------------:|:----------------------------------------------------------------:|:----------------------------------------------------------------:|
-| WithdrawAsset |   {{ networks.kusama.xcm_instructions.withdraw.total_weight }}    |   {{ networks.kusama.xcm_instructions.withdraw.ksm_cost }} KSM    |
-|  ClearOrigin  | {{ networks.kusama.xcm_instructions.clear_origin.total_weight }}  | {{ networks.kusama.xcm_instructions.clear_origin.ksm_cost }} KSM  |
-| BuyExecution  |   {{ networks.kusama.xcm_instructions.buy_exec.total_weight }}    |   {{ networks.kusama.xcm_instructions.buy_exec.ksm_cost }} KSM    |
-| DepositAsset  | {{ networks.kusama.xcm_instructions.deposit_asset.total_weight }} | {{ networks.kusama.xcm_instructions.deposit_asset.ksm_cost }} KSM |
-|   **TOTAL**   |      **{{ networks.kusama.xcm_message.transfer.weight }}**       |     **{{ networks.kusama.xcm_message.transfer.cost }} KSM**      |
+|  Instruction  |                                Weight                                |                               Cost                                |
+|:-------------:|:--------------------------------------------------------------------:|:-----------------------------------------------------------------:|
+| WithdrawAsset | {{ networks.kusama.xcm_instructions.withdraw.total_weight.display }} |   {{ networks.kusama.xcm_instructions.withdraw.ksm_cost }} KSM    |
+|  ClearOrigin  |   {{ networks.kusama.xcm_instructions.clear_origin.total_weight }}   | {{ networks.kusama.xcm_instructions.clear_origin.ksm_cost }} KSM  |
+| BuyExecution  |     {{ networks.kusama.xcm_instructions.buy_exec.total_weight }}     |   {{ networks.kusama.xcm_instructions.buy_exec.ksm_cost }} KSM    |
+| DepositAsset  |  {{ networks.kusama.xcm_instructions.deposit_asset.total_weight }}   | {{ networks.kusama.xcm_instructions.deposit_asset.ksm_cost }} KSM |
+|   **TOTAL**   |        **{{ networks.kusama.xcm_message.transfer.weight }}**         |      **{{ networks.kusama.xcm_message.transfer.cost }} KSM**      |
 
 
 ## Moonbeam-based Networks XCM Fee Calculation  {: #moonbeam-xcm-fee-calc }
@@ -206,9 +206,9 @@ Substrate has introduced a weight system that determines how heavy or, in other 
 
 Both Moonbeam and Moonriver use a fixed amount of weight for each XCM instruction. However, Moonbase Alpha (TestNet) has the generic XCM instructions benchmarked, while the fungible XCM instructions still use a fixed amount of weight per instruction. Consequently, the total weight cost of the benchmarked XCM instructions considers the number of database reads/writes in addition to the weight required for a given instruction. The breakdown of weight cost for the database operations is as follows:
 
-|     Database      |                    Read                     |                    Write                     |
-|:-----------------:|:-------------------------------------------:|:--------------------------------------------:|
-| [RocksDB (default)](https://github.com/paritytech/substrate/blob/master/frame/support/src/weights/rocksdb_weights.rs#L27-L28){target=_blank} | {{ networks.moonbase.db_weights.rocksdb_read }}  | {{ networks.moonbase.db_weights.rocksdb_write }}  |
+|                                                                   Database                                                                   |                      Read                       |                      Write                       |
+|:--------------------------------------------------------------------------------------------------------------------------------------------:|:-----------------------------------------------:|:------------------------------------------------:|
+| [RocksDB (default)](https://github.com/paritytech/substrate/blob/master/frame/support/src/weights/rocksdb_weights.rs#L27-L28){target=_blank} | {{ networks.moonbase.db_weights.rocksdb_read }} | {{ networks.moonbase.db_weights.rocksdb_write }} |
 
 Now that you know the weight costs for database reads and writes for Moonbase Alpha, you can calculate the weight cost for both fungible and generic XCM instruction using the base weight for instruction and the extra database read/writes if applicable.
 
@@ -217,24 +217,24 @@ For example, the `WithdrawAsset` instruction is part of the fungible XCM instruc
 The [`BuyExecution` instruction](https://github.com/PureStake/moonbeam/blob/master/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L220){target=_blank} has a base weight of `{{ networks.moonbase.xcm.instructions.buy_exec.base_weight }}`, and performs four database reads (`assetManager` pallet to get the `unitsPerSecond`). Therefore, the total weight cost of the `BuyExecution` instruction is calculated as follows:
 
 ```
-{{ networks.moonbase.xcm.instructions.buy_exec.base_weight }} + 4*{{ networks.moonbase.db_weights.rocksdb_read }} = {{ networks.moonbase.xcm.instructions.buy_exec.total_weight }}
+{{ networks.moonbase.xcm.instructions.buy_exec.base_weight }} + 4 * {{ networks.moonbase.db_weights.rocksdb_read }} = {{ networks.moonbase.xcm.instructions.buy_exec.total_weight }}
 ```
 
 You can find all the weight values for all the XCM instructions in the following table:
 
 === "Moonbeam"
-    | XCM Instruction Cost |
-    |:------------------------:|
+    |                                                                                            XCM Instruction Cost                                                                                             |
+    |:-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     | [{{ networks.moonbeam.xcm.instructions.weight_units.display }}](https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonbeam/src/xcm_config.rs#L201){target=_blank} |
     
 === "Moonriver"
-    | XCM Instruction Cost |
-    |:------------------------:|
+    |                                                                                             XCM Instruction Cost                                                                                              |
+    |:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     | [{{ networks.moonriver.xcm.instructions.weight_units.display }}](https://github.com/PureStake/moonbeam/blob/f19ba9de013a1c789425d3b71e8a92d54f2191af/runtime/moonriver/src/xcm_config.rs#L208){target=_blank} |
     
 === "Moonbase Alpha"
-    | Benchmarked Instructions | Non-Benchmarked Instructions |
-    |:------------------------:|:-------------------------:|
+    |                                                                             Benchmarked Instructions                                                                             |                                                                           Non-Benchmarked Instructions                                                                            |
+    |:--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|
     | [Generic XCM Instructions](https://github.com/PureStake/moonbeam/blob/master/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_generic.rs#L203){target=_blank} | [Fungible XCM Instructions](https://github.com/PureStake/moonbeam/blob/master/pallets/moonbeam-xcm-benchmarks/src/weights/moonbeam_xcm_benchmarks_fungible.rs#L26){target=_blank} |
 
 The following sections will break down how to calculate XCM fees for Moonbeam-based networks. There are two main scenarios:
@@ -260,7 +260,7 @@ GLMR = Wei / (10^18)
 Therefore, the actual calculation is:
 
 ```
-XCM-Wei-Cost = {{ networks.moonbeam.xcm.instructions.weight_units.numbers_only }} * {{ networks.moonbeam.xcm.instructions.wei_per_weight.display }}
+XCM-Wei-Cost = {{ networks.moonbeam.xcm.instructions.weight_units.numbers_only }} * {{ networks.moonbeam.xcm.instructions.wei_per_weight.numbers_only }}
 XCM-GLMR-Cost = {{ networks.moonbeam.xcm.instructions.wei_cost }} / (10^18)
 ```
 

--- a/variables.yml
+++ b/variables.yml
@@ -105,8 +105,12 @@ networks:
         account_id: '5GWpSdqkkKGZmdKQ9nkSF7TmHp6JWt28BMGQNuG4MXtSvq3e'
         account_id_hex: '0xc4db7bcb733e117c0b34ac96354b10d47e84a006b9e7e66a229d174e8ff2a063'
       instructions:
+        buy_exec:
+          base_weight: 130,464,000
+          total_weight: 230,464,000
+          ksm_cost: '0.000000120072453'
         weight_units:
-          display: 100,000,000
+          display: 200,000,000
         wei_per_weight:
           display: 50,000
       units_per_second:
@@ -236,6 +240,9 @@ networks:
       bond: 100
     multisig:
       api_page: https://transaction.moonbase.multisig.moonbeam.network/
+    db_weights:
+      rocksdb_read: 25,000,000
+      rocksdb_write: 100,000,000
   moonriver:
     public_rpc_url: https://rpc.api.moonriver.moonbeam.network # for wallets
     rpc_url: RPC-API-ENDPOINT-HERE
@@ -639,7 +646,7 @@ networks:
     parity_db:
       read_weight: 11,826,000
       write_weight: 30,052,000
-    xcm_instruction:
+    xcm_instructions:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
@@ -669,7 +676,7 @@ networks:
       transfer:
         weight: 298,368,000
         cost: '0.000011523247866'
-    xcm_instruction:
+    xcm_instructions:
       buy_exec:
         base_weight: 3,109,000
         total_weight: 3,109,000

--- a/variables.yml
+++ b/variables.yml
@@ -108,7 +108,6 @@ networks:
         buy_exec:
           base_weight: 130,464,000
           total_weight: 230,464,000
-          ksm_cost: '0.000000120072453'
         weight_units:
           display: 200,000,000
         wei_per_weight:
@@ -683,7 +682,9 @@ networks:
         ksm_cost: '0.000000120072453'
       withdraw:
         base_weight: 20,385,000
-        total_weight: 145,385,000
+        total_weight:
+          display: 145,385,000
+          numbers_only: 145385000
         planck_ksm_cost: 5614903.04216
         ksm_cost: '0.00000561490304213694'
       clear_origin:
@@ -702,7 +703,7 @@ networks:
         weight: 400,000,000
         numbers_only: 400000000
         wei_betadev_cost: 20000000000000
-        betadev_cost: 0.00002
+        betadev_cost: '0.00002'
   bobabase:
     rpc_url: https://bobabase.boba.network
     replica_rpc_url: https://replica.bobabase.boba.network


### PR DESCRIPTION
### Description

Modifies the XCM Fees page to add the newly benchmarked XCM instructions.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

https://github.com/PureStake/moonbeam-docs-cn/pull/180

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done


