### PR TITLE
Update systemd.md to mention extra Ubuntu 22.04 command and fix binary name

### DIFF
--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -93,6 +93,12 @@ The following commands will build the latest release of the Moonbeam parachain.
 
 5. Build the parachain binary:
 
+!!! note
+    If you are using Ubuntu 22.04 then you will need to run the following first:
+    ```
+    apt install protobuf-compiler libprotobuf-dev -y
+    ```
+    
     ```
     cargo build --release
     ```
@@ -183,7 +189,7 @@ The following commands will set up everything regarding running the service.
 
 The next step is to create the systemd configuration file. If you are setting up a collator node, make sure to follow the code snippets for [Collator](#collator--collator). Note that you have to:
 
- - Replace `YOUR-NODE-NAME` in two different places
+ - Replace `YOUR_NODE_NAME` in two different places
  - Replace `<50% RAM in MB>` for 50% of the actual RAM your server has. For example, for 32 GB RAM, the value must be set to `16000`. The minimum value is `2000`, but it is below the recommended specs
  - Double-check that the binary is in the proper path as described below (_ExecStart_)
  - Double-check the base path if you've used a different directory
@@ -220,13 +226,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
     
     [Install]
     WantedBy=multi-user.target
@@ -258,13 +264,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
     
     [Install]
     WantedBy=multi-user.target
@@ -296,13 +302,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
 
     [Install]
     WantedBy=multi-user.target
@@ -339,13 +345,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbeam.node_directory }} \
          --chain {{ networks.moonbeam.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
     
     [Install]
     WantedBy=multi-user.target
@@ -377,13 +383,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonriver.node_directory }} \
          --chain {{ networks.moonriver.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
     
     [Install]
     WantedBy=multi-user.target
@@ -415,13 +421,13 @@ The next step is to create the systemd configuration file. If you are setting up
          --db-cache <50% RAM in MB> \
          --base-path {{ networks.moonbase.node_directory }} \
          --chain {{ networks.moonbase.chain_spec }} \
-         --name "YOUR-NODE-NAME" \
+         --name "YOUR_NODE_NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
          --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
-         --name="YOUR-NODE-NAME (Embedded Relay)"
+         --name="YOUR_NODE_NAME_EMBEDDED_RELAY"
 
     [Install]
     WantedBy=multi-user.target


### PR DESCRIPTION
### Description

Update includes mentioning that `apt install protobuf-compiler libprotobuf-dev -y` needs to be run before `cargo build --release` on Ubuntu 22.04, otherwise the user will wait a long time for it to built only to encounter the following error
```
   Compiling precompile-utils-macro v0.1.0 (/root/code/moonbeam/precompiles/utils/macro)
error: failed to run custom build command for `libp2p-core v0.37.0`

Caused by:
  process didn't exit successfully: `/root/code/moonbeam/target/release/build/libp2p-core-1e11a45529ee4184/build-script-build` (exit status: 101)
  --- stderr
  thread 'main' panicked at '
  Could not find `protoc` installation and this build crate cannot proceed without
  this knowledge. If `protoc` is installed and this crate had trouble finding
  it, you can set the `PROTOC` environment variable with the specific path to your
  installed `protoc` binary.

  For more information: https://docs.rs/prost-build/#sourcing-protoc
  ', /root/.cargo/registry/src/github.com-1ecc6299db9ec823/prost-build-0.11.1/src/lib.rs:1227:10
  note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Also update includes changing the parachain and relay chain names to only include the underscore character, since horizontal dash (i.e. `-`) and braces (i.e. `(`) cause errors like the following when you run the node:
```
Dec 22 11:32:03 localhost moonbase[218583]: /opt/moonbase/start.sh: line 43: syntax error near unexpected token `('
Dec 22 11:32:03 localhost moonbase[218583]: /opt/moonbase/start.sh: line 43: `    --name "YOUR-NODE-NAME (Embedded Relay)"'
```

Note that i'm not sure what the workaround is to get `-` and `(` to work, but it appears possible since plenty of nodes are doing it https://telemetry.polkadot.io/#list/0x91bc6e169807aaa54802737e1c504b2577d4fafedd5a02c10293b1cd60e39527

### Checklist

N/A

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

N/A

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

N/A

Please list any of the items that will need to be added or deleted after the translations are done here.
