### PR TITLE
Update bn128pairing.md

### DIFF
--- a/.snippets/code/precompiles/bn128pairing.md
+++ b/.snippets/code/precompiles/bn128pairing.md
@@ -8,7 +8,7 @@ contract Precompiles {
         require(len % 192 == 0);
         assembly {
             let memPtr := mload(0x40)
-            let success := call(gas, 0x08, 0, add(input, 0x20), len, memPtr, 0x20)
+            let success := call(gas(), 0x08, 0, add(input, 0x20), len, memPtr, 0x20)
             switch success
             case 0 {
                 revert(0,0)


### PR DESCRIPTION
Added missing parentheses on `gas()` to make the code run.