### PR TITLE
minor update to preimage migration description

### DIFF
--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -448,7 +448,7 @@ There was a migration applied to the `TransactInfo` storage item of the XCM-tran
 
 - `max_weight` is added to prevent transactors from stalling the queue in the destination chain
 - Removes `fee_per_byte`, `metadata_size`, and `base_weight` as these items are not necessary for XCM transactions
-- `fee_per_second` replaces `fee_per_weight` to better reflect cases (like Kusama) in which the `fee_per_eight` unit is lower than one
+- `fee_per_second` replaces `fee_per_weight` to better reflect cases (like Kusama) in which the `fee_per_weight` unit is lower than one
 
 This migration was executed at the following runtimes and blocks:
 

--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -234,9 +234,7 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 There was a migration applied which moved preimages stored in the democracy pallet to a new preimage pallet. This migration on Moonbeam was required as a result of an [upstream change to Polkadot](https://github.com/paritytech/substrate/pull/11649){target=_blank}.
 
-As a result, any registered preimages in democracy at the time of migration were dropped and any associated balance was not unreserved. In addition, any proposals scheduled for dispatch by democracy at the time of migration were not executed.
-
-There was one preimage that was affected in Moonbeam, which was dropped from the scheduler queue and never executed: `0x14262a42aa6ccb3cae0a169b939ca5b185bc317bb7c449ca1741a0600008d306`.
+There was one preimage that was affected in Moonbeam, which was dropped from the scheduler queue and never executed: `0x14262a42aa6ccb3cae0a169b939ca5b185bc317bb7c449ca1741a0600008d306`. This preimage was [manually removed](https://moonbeam.subscan.io/extrinsic/2693398-8){target=_blank} by the account that initially submitted the preimage.
 
 This migration was executed at the following runtimes and blocks:
 


### PR DESCRIPTION
### Description

Update the description for this migration: https://docs.moonbeam.network/builders/build/historical-updates/#preimage-storage-moved-to-new-preimage-pallet

It wasn't necessary to add in the details about the preimages being dropped as the migration took care of this with the one exception. So instead I elaborated on what happened to the one preimage, where the owner had to manually remove it 

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a