### PR TITLE
add educational tutorial disclaimer

### DIFF
--- a/.snippets/text/disclaimers/educational-tutorial.md
+++ b/.snippets/text/disclaimers/educational-tutorial.md
@@ -1,0 +1,3 @@
+<div class="page-disclaimer">
+    This tutorial is for educational purposes only. As such, any contracts or code created in this tutorial should not be used in production.
+</div>

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -49,7 +49,7 @@ To get started, you'll need to head to [Blast](https://blastapi.io/){target=_bla
 4. Confirm the selected network and Press **Activate**
 5. You'll now see your chosen network under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page 
 
-![Bware Labs](/images/builders/get-started/endpoints/endpoints-2.png)
+![Bware Labs](/images/builders/get-started/endpoints/endpoints-1.png)
 
 ### GetBlock {: #getblock }
 
@@ -63,7 +63,7 @@ Creating a new API key is simple, all you have to do is:
 2. Enter a name for your API key
 3. Click **Create** to generate your API key
 
-![GetBlock](/images/builders/get-started/endpoints/endpoints-3.png)
+![GetBlock](/images/builders/get-started/endpoints/endpoints-2.png)
 
 ### OnFinality {: #onfinality }
 
@@ -75,7 +75,7 @@ To create a custom OnFinality endpoint, go to [OnFinality](https://onfinality.io
 2. Select the network from the dropdown
 3. Your custom API endpoint will be generated automatically
 
-![OnFinality](/images/builders/get-started/endpoints/endpoints-4.png)
+![OnFinality](/images/builders/get-started/endpoints/endpoints-3.png)
 
 ### Pocket Network {: #pokt }
 
@@ -88,7 +88,7 @@ To get your own endpoint, go to [Pocket Network](https://mainnet.portal.pokt.net
 3. Enter the name of your DApp and select your corresponding network
 4. Your new endpoint will be generated and displayed for you in the following app screen
 
-![Pocket Network](/images/builders/get-started/endpoints/endpoints-5.png)
+![Pocket Network](/images/builders/get-started/endpoints/endpoints-4.png)
 
 You don't have to generate a new DApp for every endpoint! You can add a new chain to your preexisting DApp:  
 

--- a/builders/get-started/endpoints.md
+++ b/builders/get-started/endpoints.md
@@ -49,7 +49,7 @@ To get started, you'll need to head to [Blast](https://blastapi.io/){target=_bla
 4. Confirm the selected network and Press **Activate**
 5. You'll now see your chosen network under **Active Endpoints**. Click on the network and you'll see your custom RPC and WSS endpoints on the next page 
 
-![Bware Labs](/images/builders/get-started/endpoints/endpoints-1.png)
+![Bware Labs](/images/builders/get-started/endpoints/endpoints-2.png)
 
 ### GetBlock {: #getblock }
 
@@ -63,7 +63,7 @@ Creating a new API key is simple, all you have to do is:
 2. Enter a name for your API key
 3. Click **Create** to generate your API key
 
-![GetBlock](/images/builders/get-started/endpoints/endpoints-2.png)
+![GetBlock](/images/builders/get-started/endpoints/endpoints-3.png)
 
 ### OnFinality {: #onfinality }
 
@@ -75,7 +75,7 @@ To create a custom OnFinality endpoint, go to [OnFinality](https://onfinality.io
 2. Select the network from the dropdown
 3. Your custom API endpoint will be generated automatically
 
-![OnFinality](/images/builders/get-started/endpoints/endpoints-3.png)
+![OnFinality](/images/builders/get-started/endpoints/endpoints-4.png)
 
 ### Pocket Network {: #pokt }
 
@@ -88,7 +88,7 @@ To get your own endpoint, go to [Pocket Network](https://mainnet.portal.pokt.net
 3. Enter the name of your DApp and select your corresponding network
 4. Your new endpoint will be generated and displayed for you in the following app screen
 
-![Pocket Network](/images/builders/get-started/endpoints/endpoints-4.png)
+![Pocket Network](/images/builders/get-started/endpoints/endpoints-5.png)
 
 You don't have to generate a new DApp for every endpoint! You can add a new chain to your preexisting DApp:  
 

--- a/tutorials/batch-approve-swap.md
+++ b/tutorials/batch-approve-swap.md
@@ -399,4 +399,6 @@ main();
 
 This will result in the approval and swap being batched into a single transaction and the transaction hash will be printed to the console. You can now adapt and apply this logic to your Uniswap V2-style application!
 
+--8<-- 'text/disclaimers/educational-tutorial.md'
+
 --8<-- 'text/disclaimers/third-party-content.md'

--- a/tutorials/remote-staking-xcm.md
+++ b/tutorials/remote-staking-xcm.md
@@ -341,3 +341,4 @@ In the above snippet, besides submitting the remote staking via XCM transaction,
 
 And that’s it! To verify that your delegation was successful, you can visit [Subscan](https://moonbase.subscan.io/){target=_blank} to check your staking balance. Be advised that it may take a few minutes before your staking balance is visible on Subscan. Additionally, be aware that you will not be able to see this staking operation on Moonscan, because we initiated the delegation action directly via the parachain staking pallet (on the Substrate side) rather than through the staking precompile (on the EVM). 
  
+ --8<-- 'text/disclaimers/educational-tutorial.md'


### PR DESCRIPTION
### Description

Add generic disclaimer that the contracts/code created in tutorials are for educational purposes only.

⚠️ This will need to be added to the other tutorials that are in review before merging, or if they get merged first, then we will need to update this PR before merging 🙂 

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a