### PR TITLE
update xcm fees for polkadot v0.9.34 and kusama v0.9.37

### DIFF
--- a/builders/interoperability/xcm/fees.md
+++ b/builders/interoperability/xcm/fees.md
@@ -79,12 +79,12 @@ Although Polkadot doesn't currently use database weight units to calculate costs
 
 |                                                                     Database                                                                     |                     Read                      |                     Write                      |
 |:------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------:|:----------------------------------------------:|
-| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
+| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
 
 With the instruction weight cost established, you can calculate the cost of each instruction in DOT. 
 
-In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/master/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
+In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L56){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
 
 Therefore, to calculate the cost of executing an XCM instruction, you can use the following formula:
 
@@ -136,24 +136,24 @@ The total weight costs on Kusama take into consideration database reads and writ
 
 |                                                                    Database                                                                    |                    Read                     |                    Write                     |
 |:----------------------------------------------------------------------------------------------------------------------------------------------:|:-------------------------------------------:|:--------------------------------------------:|
-| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.kusama.rocks_db.read_weight }}  | {{ networks.kusama.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.kusama.parity_db.read_weight }} | {{ networks.kusama.parity_db.write_weight }} |
+| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.kusama.rocks_db.read_weight }}  | {{ networks.kusama.rocks_db.write_weight }}  |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.kusama.parity_db.read_weight }} | {{ networks.kusama.parity_db.write_weight }} |
 
 Now that you are aware of the weight costs for database reads and writes on Kusama, you can calculate the weight cost for a given instruction using the base weight for an instruction. 
 
-For example, the [`WithdrawAsset` instruction](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs#L49-L53){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.withdraw.base_weight }}`, and performs one database read, and one database write. Therefore, the total weight cost of the `WithdrawAsset` instruction is calculated as:
+For example, the [`WithdrawAsset` instruction](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs#L49-L53){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.withdraw.base_weight }}`, and performs one database read, and one database write. Therefore, the total weight cost of the `WithdrawAsset` instruction is calculated as:
 
 ```
 {{ networks.kusama.xcm_instructions.withdraw.base_weight }} + {{ networks.kusama.rocks_db.read_weight}} + {{ networks.kusama.rocks_db.write_weight}} = {{ networks.kusama.xcm_instructions.withdraw.total_weight.display }}
 ```
 
-The [`BuyExecution` instruction](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs#L59-L61){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.buy_exec.base_weight }}` and doesn't include any database reads or writes. Therefore, the total weight cost of the `BuyExecution` instruction is `{{ networks.kusama.xcm_instructions.buy_exec.total_weight }}`.
+The [`BuyExecution` instruction](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs#L59-L61){target=_blank} has a base weight of `{{ networks.kusama.xcm_instructions.buy_exec.base_weight }}` and doesn't include any database reads or writes. Therefore, the total weight cost of the `BuyExecution` instruction is `{{ networks.kusama.xcm_instructions.buy_exec.total_weight }}`.
 
-On Kusama, the benchmarked base weights are broken up into two categories: fungible and generic. Fungible weights are for XCM instructions that involve moving assets, and generic weights are for everything else. You can view the current weights for [fungible assets](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs#L45){target=_blank} and [generic assets](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs#L46){target=_blank} directly in the Kusama Runtime code.
+On Kusama, the benchmarked base weights are broken up into two categories: fungible and generic. Fungible weights are for XCM instructions that involve moving assets, and generic weights are for everything else. You can view the current weights for [fungible assets](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_fungible.rs#L45){target=_blank} and [generic assets](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/src/weights/xcm/pallet_xcm_benchmarks_generic.rs#L45){target=_blank} directly in the Kusama Runtime code.
 
 With the instruction weight cost established, you can calculate the cost of the instruction in KSM. 
 
-In Kusama, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.kusama.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/master/runtime/kusama/constants/src/lib.rs#L87){target=_blank} of a cent. Where 1 cent is `10^12 / 30,000`.
+In Kusama, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.kusama.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/constants/src/lib.rs#L87){target=_blank} of a cent. Where 1 cent is `10^12 / 30,000`.
 
 Therefore, to calculate the cost of executing an XCM instruction, you can use the following formula:
 
@@ -164,13 +164,13 @@ XCM-KSM-Cost = XCMInstrWeight * KSMWeightToFeeCoefficient
 Where `KSMWeightToFeeCoefficient` is a constant (map to 1 cent), and can be calculated as:
 
 ```
-KSMWeightToFeeCoefficient = ( 10^12 / ( 10 * 30000 )) * ( 1 / KSMExtrinsicBaseWeight )
+KSMWeightToFeeCoefficient = ( 10^12 / ( 10 * 3000 )) * ( 1 / KSMExtrinsicBaseWeight )
 ```
 
 Using the actual values:
 
 ```
-KSMWeightToFeeCoefficient = ( 10^12 / ( 10 * 30000 * {{ networks.kusama.extrinsic_base_weight.numbers_only }} )
+KSMWeightToFeeCoefficient = ( 10^12 / ( 10 * 3000 * {{ networks.kusama.extrinsic_base_weight.numbers_only }} )
 ```
 
 As a result, `KSMWeightToFeeCoefficient` is equal to `{{ networks.kusama.xcm_instructions.planck_ksm_weight }} Planck-KSM`. Now, you can begin to calculate the final fee in KSM, using `KSMWeightToFeeCoefficient` as a constant and `TotalWeight` ({{ networks.kusama.xcm_instructions.withdraw.total_weight.display }}) as the variable:

--- a/variables.yml
+++ b/variables.yml
@@ -641,21 +641,21 @@ networks:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
-      planck_dot_weight: 0.10473507263
-      planck_dot_cost: 104735072.63
-      dot_cost: 0.01047350726
+      planck_dot_weight: 0.10535853509
+      planck_dot_cost: 105358535.09
+      dot_cost: 0.0105358535
     xcm_message:
       transfer:
         weight: 4,000,000,000
-        cost: 0.04189402904
+        cost: 0.042143414
       transact:
         weight: 3,000,000,000
         numbers_only: 3000000000
         planck_dot_cost: 362078329.611
         dot_cost: 0.0362078329611
     extrinsic_base_weight:
-      display: 95,479,000
-      numbers_only: 95479000
+      display: 94,914,000
+      numbers_only: 94914000
   kusama:
     rocks_db:
       read_weight: 25,000,000
@@ -666,7 +666,7 @@ networks:
     xcm_message:
       transfer:
         weight: 298,368,000
-        cost: '0.00001048129'
+        cost: '0.00001046953'
     xcm_instructions:
       buy_exec:
         base_weight: 3,109,000
@@ -677,18 +677,18 @@ networks:
         total_weight:
           display: 145,385,000
           numbers_only: 145385000
-        planck_ksm_cost: 5107195.42392
-        ksm_cost: '0.000005107190'
+        planck_ksm_cost: 5095435.36358
+        ksm_cost: '0.00000509543'
       clear_origin:
         total_weight: 3,111,000
         ksm_cost: '0.000000109286'
       deposit_asset:
         total_weight: 146,763,000
         ksm_cost: '0.000005155600'
-      planck_ksm_weight: 0.03512876448
+      planck_ksm_weight: 0.03504787539
     extrinsic_base_weight:
-      display: 94,889,000
-      numbers_only: 94889000
+      display: 95,108,000
+      numbers_only: 95108000
   moonbase_beta:
     xcm_message:
       transact:

--- a/variables.yml
+++ b/variables.yml
@@ -641,21 +641,21 @@ networks:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
-      planck_dot_weight: 0.10535853509
-      planck_dot_cost: 105358535.09
-      dot_cost: 0.0105358535
+      planck_dot_weight: 0.11735436323
+      planck_dot_cost: 117354363.23
+      dot_cost: 0.01173543632
     xcm_message:
       transfer:
         weight: 4,000,000,000
-        cost: 0.042143414
+        cost: 0.04694174528
       transact:
         weight: 3,000,000,000
         numbers_only: 3000000000
         planck_dot_cost: 362078329.611
         dot_cost: 0.0362078329611
     extrinsic_base_weight:
-      display: 94,914,000
-      numbers_only: 94914000
+      display: 85,212,000
+      numbers_only: 85212000
   kusama:
     rocks_db:
       read_weight: 25,000,000
@@ -666,26 +666,26 @@ networks:
     xcm_message:
       transfer:
         weight: 298,368,000
-        cost: '0.00001046953'
+        cost: '0.00010457164'
     xcm_instructions:
       buy_exec:
         base_weight: 3,109,000
         total_weight: 3,109,000
-        ksm_cost: '0.000000109215'
+        ksm_cost: '0.00000108963'
       withdraw:
         base_weight: 20,385,000
         total_weight:
           display: 145,385,000
           numbers_only: 145385000
-        planck_ksm_cost: 5095435.36358
-        ksm_cost: '0.00000509543'
+        planck_ksm_cost: 50954353.6459
+        ksm_cost: '0.00005095435'
       clear_origin:
         total_weight: 3,111,000
-        ksm_cost: '0.000000109286'
+        ksm_cost: '0.00000109033'
       deposit_asset:
         total_weight: 146,763,000
-        ksm_cost: '0.000005155600'
-      planck_ksm_weight: 0.03504787539
+        ksm_cost: '0.00005143731'
+      planck_ksm_weight: 0.35047875397
     extrinsic_base_weight:
       display: 95,108,000
       numbers_only: 95108000


### PR DESCRIPTION
### Description

base extrinsic weights have changed for both polkadot and kusama in v0.9.37 release:
- Kusama -https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/kusama/constants/src/weights/extrinsic_weights.rs#L55
- Polkadot -  https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L55

Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/217