### PR TITLE
base fee pallet is no longer used

### DIFF
--- a/learn/features/eth-compatibility.md
+++ b/learn/features/eth-compatibility.md
@@ -32,10 +32,10 @@ Moonbeam supports:
 
 - **[EVM pallet](#evm-pallet){target=_blank}** - handles EVM execution
 - **[Ethereum pallet](#ethereum-pallet){target=_blank}** - is responsible for storing block data and provides RPC compatibility
-- **[Base fee pallet](#base-fee-pallet){target=_blank}** - adds support for EIP-1559 transactions and handles base fee calculations
+- **Base fee pallet** - adds support for EIP-1559 transactions and handles base fee calculations
 - **Dynamic fee pallet** - calculates the dynamic minimum gas price
 
-Moonbeam uses the EVM, Ethereum, and base fee pallets to achieve full Ethereum compatibility. Moonbeam does not use the dynamic fee pallet.
+Moonbeam uses the EVM and Ethereum pallets to achieve full Ethereum compatibility. Moonbeam does not currently use the base fee pallet or dynamic fee pallet. However, prior to Runtime 2100, Moonbeam relied on the base fee pallet to calculate base transaction fees. These calculations now rely on [pallet EVM's minimum gas price method](https://paritytech.github.io/frontier/rustdocs/pallet_evm/trait.FeeCalculator.html#tymethod.min_gas_price){target=_blank}.
 
 ### EVM Pallet {: #evm-pallet }
 
@@ -71,7 +71,3 @@ The [Ethereum pallet](https://paritytech.github.io/frontier/frame/ethereum.html)
 When a user submits a raw Ethereum transaction, it gets converted into a Substrate transaction through the pallet Ethereum's `transact` extrinsic. Using the Ethereum pallet as the sole executor of the EVM pallet, forces all of the data to be stored and transacted with in an Ethereum-compatible way. This enables block explorers such as [Moonscan](/builders/get-started/explorers#moonscan), which is built by Etherscan, to be able to index block data.
 
 Along with support for Ethereum-style data, the Ethereum pallet combined with the [RPC module](https://github.com/paritytech/frontier/tree/master/client/rpc){target=_blank} provides RPC support. This enables usage of [basic Ethereum JSON-RPC methods](/builders/get-started/eth-compare/rpc-support#basic-ethereum-json-rpc-methods){target=_blank} which ultimately allows existing Ethereum DApps to be deployed to Moonbeam with minimal changes. 
-
-### Base Fee Pallet {: #base-fee-pallet }
-
-The base fee pallet is responsible for calculating the base fee for EIP-1559 transactions. The algorithm follows the one outlined in the [EIP-1559 standard](https://eips.ethereum.org/EIPS/eip-1559){target=_blank}. In conjuction with the EVM pallet and the Ethereum pallet, `maxFeePerGas` and `maxPriorityFeePerGas` can be used instead of `gasPrice`, ultimately adding support for EIP-1559 transactions on Moonbeam.

--- a/learn/features/eth-compatibility.md
+++ b/learn/features/eth-compatibility.md
@@ -35,7 +35,7 @@ Moonbeam supports:
 - **Base fee pallet** - adds support for EIP-1559 transactions and handles base fee calculations
 - **Dynamic fee pallet** - calculates the dynamic minimum gas price
 
-Moonbeam uses the EVM and Ethereum pallets to achieve full Ethereum compatibility. Moonbeam does not currently use the base fee pallet or dynamic fee pallet. However, prior to Runtime 2100, Moonbeam relied on the base fee pallet to calculate base transaction fees. These calculations now rely on [pallet EVM's minimum gas price method](https://paritytech.github.io/frontier/rustdocs/pallet_evm/trait.FeeCalculator.html#tymethod.min_gas_price){target=_blank}.
+Moonbeam uses the EVM and Ethereum pallets to achieve full Ethereum compatibility. Moonbeam does not use the base fee or dynamic fee pallets. Moonbeam has its own [dynamic fee mechanism](https://forum.moonbeam.foundation/t/proposal-status-idea-dynamic-fee-mechanism-for-moonbeam-and-moonriver/241){target=_blank} for base fee calculations, which, as of RT2100, has been rolled out to Moonbase Alpha. Currently, Moonbeam and Moonriver have a static, hard-coded base fee while the dynamic fee system is being tested on Moonbase Alpha.
 
 ### EVM Pallet {: #evm-pallet }
 


### PR DESCRIPTION
### Description

Update the frontier section of the ethereum compatibility change where we previously mentioned that we use the base fee pallet as this is no longer the case!

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

n/a

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done

#### Items to be Updated

n/a