### PR TITLE
update RT2100 changes as they only apply to MBA

### DIFF
--- a/.snippets/code/vs-ethereum/tx-fees-block-2000.md
+++ b/.snippets/code/vs-ethereum/tx-fees-block-2000.md
@@ -1,10 +1,10 @@
 ```ts
 const axios = require("axios");
 
-// This script calculates the transaction fees of all transactions in a Moonbeam block
-// block (as of RT2000) according to the transaction type (For Ethereum API: legacy, 
-// EIP-1559 or EIP-2930 standards, and Substrate API), as well as calculating the total
-// fees in the block.
+// This script calculates the transaction fees of all transactions in a Moonbeam, Moonriver
+// or Moonbase Alpha (as of RT2000) block according to the transaction type (For Ethereum API: 
+// legacy, EIP-1559 or EIP-2930 standards, and Substrate API), as well as calculating
+// the total fees in the block.
 
 // Define static base fee per network
 const baseFee = {

--- a/.snippets/code/vs-ethereum/tx-fees-block-2000.md
+++ b/.snippets/code/vs-ethereum/tx-fees-block-2000.md
@@ -2,8 +2,9 @@
 const axios = require("axios");
 
 // This script calculates the transaction fees of all transactions in a Moonbeam block
-// according to the transaction type (For Ethereum API: legacy, EIP-1559 or EIP-2930 standards,
-//and Substrate API), as well as calculating the total fees in the block.
+// block (as of RT2000) according to the transaction type (For Ethereum API: legacy, 
+// EIP-1559 or EIP-2930 standards, and Substrate API), as well as calculating the total
+// fees in the block.
 
 // Define static base fee per network
 const baseFee = {

--- a/.snippets/code/vs-ethereum/tx-fees-block-2100.md
+++ b/.snippets/code/vs-ethereum/tx-fees-block-2100.md
@@ -1,9 +1,10 @@
 ```ts
 const axios = require('axios');
 
-// This script calculates the transaction fees of all transactions in a Moonbeam block
-// according to the transaction type (For Ethereum API: legacy, EIP-1559 or EIP-2930 standards,
-//and Substrate API), as well as calculating the total fees in the block.
+// This script calculates the transaction fees of all transactions in a Moonbase Alpha
+// block (as of RT2100) according to the transaction type (For Ethereum API: legacy,
+// EIP-1559 or EIP-2930 standards, and Substrate API), as well as calculating the total
+// fees in the block.
 
 // Endpoint to retrieve the latest block
 const endpointBlock = 'http://127.0.0.1:8080/blocks/head';

--- a/builders/get-started/eth-compare/tx-fees.md
+++ b/builders/get-started/eth-compare/tx-fees.md
@@ -80,7 +80,6 @@ To calculate the fee incurred on a Moonbeam transaction sent via the Ethereum AP
 
 === "EIP-1559"
     ```
-    BaseFee = NextFeeMultiplier * 1250000000 / 10^18
     GasPrice = BaseFee + MaxPriorityFeePerGas < MaxFeePerGas ? 
                 BaseFee + MaxPriorityFeePerGas : 
                 MaxFeePerGas;
@@ -96,7 +95,7 @@ To calculate the fee incurred on a Moonbeam transaction sent via the Ethereum AP
     ```
 
 !!! note
-    The `BaseFee` value should only be calculated if calculating for RT2100 or later. Otherwise, you should use a constant value as described later in the section.
+    If calculating the transaction fee for RT2100 or later on **Moonbase Alpha only**, you'll need to calculate the `BaseFee` using: `BaseFee = NextFeeMultiplier * 1250000000 / 10^18`. For Moonbeam or Moonriver, or Moonbase Alpha prior to RT2100, you can use the constant `BaseFee` values outlined below.
 
 The following sections describe in more detail each of the components to calculate the transaction fee.
 
@@ -104,7 +103,24 @@ The following sections describe in more detail each of the components to calcula
 
 The `BaseFee` was introduced in [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559){target=_blank}, and is a value set by the network itself. 
 
-**RT2100** introduced a new dynamic fee mechanism that closely resembles [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559){target=_blank}, where the `BaseFee` is adjusted based on block congestion. Consequently, you need to estimate the `BaseFee` for each block using `NextFeeMultiplier`. The value of `NextFeeMultiplier` can be retrieved from the Substrate Sidecar API, via the following endpoint:
+The `BaseFee` is static on Moonbeam and Moonriver, and as of RT2100, is dynamic on Moonbase Alpha. The static base fee for each network has the following assigned value:
+
+=== "Moonbeam"
+    | Variable |  Value   |
+    |:--------:|:--------:|
+    | BaseFee  | 100 Gwei |
+
+=== "Moonriver"
+    | Variable | Value  |
+    |:--------:|:------:|
+    | BaseFee  | 1 Gwei |
+
+=== "Moonbase Alpha (prior to RT2100)"
+    | Variable | Value  |
+    |:--------:|:------:|
+    | BaseFee  | 1 Gwei |
+
+**RT2100** introduced a new dynamic fee mechanism to **Moonbase Alpha only** that closely resembles [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559){target=_blank}, where the `BaseFee` is adjusted based on block congestion. Consequently, you need to estimate the `BaseFee` for each block using `NextFeeMultiplier`. The value of `NextFeeMultiplier` can be retrieved from the Substrate Sidecar API, via the following endpoint:
 
 ```
 GET /pallets/transaction-payment/storage/nextFeeMultiplier?at={blockId}
@@ -125,24 +141,6 @@ RESPONSE JSON Storage Object:
 ```
 
 The relevant data will be stored in the `value` key of the JSON object. This value is a fixed point data type, hence the real value is found by divided the `value` by `10^18`. This is why [the calculation of `BaseFee`](#ethereum-api-transaction-fees) includes such an operation. Please review the [RT2100 sample code](/builders/get-started/eth-compare/tx-fees/#sample-code) provided at the end of this page.
-
-
-**Before RT2100**, the `BaseFee` was static on Moonbeam networks and had the following assigned value:
-
-=== "Moonbeam"
-    | Variable |  Value   |
-    |:--------:|:--------:|
-    | BaseFee  | 100 Gwei |
-
-=== "Moonriver"
-    | Variable | Value  |
-    |:--------:|:------:|
-    | BaseFee  | 1 Gwei |
-
-=== "Moonbase Alpha"
-    | Variable | Value  |
-    |:--------:|:------:|
-    | BaseFee  | 1 Gwei |
 
 ### GasPrice, MaxFeePerGas and MaxPriorityFeePerGas {: #gasprice-maxfeepergas-maxpriorityfeepergas }
 
@@ -188,7 +186,7 @@ extrinsics[extrinsic_number].events[event_number].data[0].weight
 
 As seen in the sections above, there are some key differences between the transaction fee model on Moonbeam and the one on Ethereum that developers should be mindful of when developing on Moonbeam:
 
-  - With the introduction of **RT2100**, the [dynamic fee mechanism](https://forum.moonbeam.foundation/t/proposal-status-idea-dynamic-fee-mechanism-for-moonbeam-and-moonriver/241){target=_blank} used in Moonbeam-based networks resembles that of [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559){target=_blank} but the implementation is different
+  - With the introduction of **RT2100**, the [dynamic fee mechanism](https://forum.moonbeam.foundation/t/proposal-status-idea-dynamic-fee-mechanism-for-moonbeam-and-moonriver/241){target=_blank} used in Moonbase Alpha resembles that of [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559){target=_blank} but the implementation is different
 
   - The amount of gas used in Moonbeam's transaction fee model is mapped from the transaction's Substrate extrinsic weight value via a fixed factor of {{ networks.moonbase.tx_weight_to_gas_ratio }}. This value is then multiplied with the unit gas price to calculate the transaction fee. This fee model means it can potentially be significantly cheaper to send transactions such as basic balance transfers via the Ethereum API than the Substrate API
 
@@ -253,12 +251,14 @@ The following curl example will return the gas information of the last 10 blocks
 
 The following code snippet uses the [Axios HTTP client](https://axios-http.com/){target=_blank} to query the [Sidecar endpoint `/blocks/head`](https://paritytech.github.io/substrate-api-sidecar/dist/#operations-tag-blocks){target=_blank} for the latest finalized block. It then calculates the transaction fees of all transactions in the block according to the transaction type (for Ethereum API: legacy, EIP-1559 or EIP-2930 standards, and for Substrate API), as well as calculating the total transaction fees in the block. 
 
+The dynamic fee calculation snippet below is only applicable to Moonbase Alpha as of RT2100. So, if you're calculating fees for Moonbase Alpha prior to RT2100, or for Moonbeam or Moonriver, please use the static fee calculation snippet.
+
 The following code sample is for demo purposes only and should not be used without modification and further testing in a production environment. 
 
-=== "RT2100"
-    --8<-- 'code/vs-ethereum/tx-fees-block-2100.md'
-
-=== "RT2000"
+=== "Static Fee Calculation"
     --8<-- 'code/vs-ethereum/tx-fees-block-2000.md'
+
+=== "Dynamic Fee Calculation (Moonbase Alpha only)"
+    --8<-- 'code/vs-ethereum/tx-fees-block-2100.md'
 
 --8<-- 'text/disclaimers/third-party-content.md'


### PR DESCRIPTION
### Description

Update the transaction fees page as the dynamic fee calculation only applies to Moonbase Alpha as of RT2100. Re-prioritize the sections so that the static `BaseFee` for Moonbeam and Moonriver are the main focus.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
