### PR TITLE
bump to v0.29.0

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -46,7 +46,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -64,7 +64,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -82,7 +82,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \
@@ -100,7 +100,7 @@ purestake/moonbeam:v0.28.1 \
 ```
 docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.28.1 \
+purestake/moonbeam:v0.29.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
-    build_tag: v0.28.1
-    tracing_tag: purestake/moonbeam-tracing:v0.28.1-2000-latest
+    build_tag: v0.29.0
+    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
     rpc_url: http://127.0.0.1:9933
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -15,9 +15,9 @@ networks:
     hex_chain_id: '0x507'
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
-    parachain_release_tag: v0.28.1 # must be in this exact format for links to work
-    parachain_sha256sum: 8b77ef15a150b0e1e83408d0ad0bab0b6b3514cfaaf0ad6efb696167a4473ad7
-    tracing_tag: purestake/moonbeam-tracing:v0.28.1-2000-latest
+    parachain_release_tag: v0.29.0 # must be in this exact format for links to work
+    parachain_sha256sum: afc7f4cf869fea6af3e4d104b5e99b764df6baca8b6157cc4e1fd8a345e75623
+    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data
@@ -247,9 +247,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.28.1
-    parachain_sha256sum: 8b77ef15a150b0e1e83408d0ad0bab0b6b3514cfaaf0ad6efb696167a4473ad7
-    tracing_tag: purestake/moonbeam-tracing:v0.28.1-2000-latest
+    parachain_release_tag: v0.29.0
+    parachain_sha256sum: afc7f4cf869fea6af3e4d104b5e99b764df6baca8b6157cc4e1fd8a345e75623
+    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam


### PR DESCRIPTION
### Description

This PR bumps the client version to v0.29.0 for moonriver and moonbase alpha 
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/222
