### PR TITLE
Change xcm-sdk page showing changes to toDecimal function return type

### DIFF
--- a/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
@@ -390,7 +390,7 @@ async function deposit() {
     `Your ${asset.originSymbol} balance in ${source.name}: ${toDecimal(
       sourceBalance,
       asset.decimals,
-    )}. Minimum transferable amount is: ${toDecimal(min, asset.decimals)}`,
+    ).toFixed()}. Minimum transferable amount is: ${toDecimal(min, asset.decimals).toFixed()}`,
   );
 
   await send('INSERT-AMOUNT', (event) => console.log(event));
@@ -579,7 +579,7 @@ async function getDepositFee() {
   );
 
   const fee = await getFee('INSERT-AMOUNT'));
-  console.log(`Fee to deposit is estimated to be: ${toDecimal(fee, asset.decimals)} ${dot}`);
+  console.log(`Fee to deposit is estimated to be: ${toDecimal(fee, asset.decimals).toFixed()} ${dot}`);
 }
 
 getDepositFee();
@@ -622,7 +622,7 @@ async function withdraw() {
     `Your ${asset.originSymbol} balance in ${destination.name}: ${toDecimal(
       destinationBalance,
       asset.decimals,
-    )}. Minimum transferable amount is: ${toDecimal(min, asset.decimals)}`,
+    ).toFixed()}. Minimum transferable amount is: ${toDecimal(min, asset.decimals).toFixed()}`,
   );
 
   await send('INSERT-AMOUNT', (event) => console.log(event));
@@ -774,7 +774,7 @@ async function getWithdrawFee() {
   );
 
   const fee = await getFee('INSERT-AMOUNT'));
-  console.log(`Fee to deposit is estimated to be: ${toDecimal(fee, moonbeam.moonChain.decimals)} ${moonbeam.moonAsset.originSymbol}`););
+  console.log(`Fee to deposit is estimated to be: ${toDecimal(fee, moonbeam.moonChain.decimals).toFixed()} ${moonbeam.moonAsset.originSymbol}`););
 }
 
 getWithdrawFee();
@@ -810,7 +810,7 @@ const unsubscribe = await moonbeam.subscribeToAssetsBalanceInfo(
   (balances) => {
     balances.forEach(({ asset, balance, origin }) => {
       console.log(
-        `${balance.symbol}: ${toDecimal(balance.balance, balance.decimals)} (${
+        `${balance.symbol}: ${toDecimal(balance.balance, balance.decimals).toFixed()} (${
           origin.name
         } ${asset.originSymbol})`,
       );
@@ -823,7 +823,7 @@ unsubscribe();
 
 ### Utility Functions {: #sdk-utils }
 
-The XCM SDK provides three utility functions: `isXcmSdkDeposit`, `isXcmSdkWithdraw`, and XCM UTILS `toDecimal`, and `toBigInt`.
+The XCM SDK provides three utility functions: `isXcmSdkDeposit`, `isXcmSdkWithdraw`, and XCM UTILS `toDecimal`, `toBigInt` and `hasDecimalOverflow`.
 
 #### Check if Transfer Data is for a Deposit  {: #deposit-check }
 
@@ -875,18 +875,21 @@ console.log(isXcmSdkDeposit(deposit)) // Returns false
 
 #### Convert Balance to Decimal or BigInt {: #decimals }
 
-To convert a balance to decimal format, you can use the `toDecimal` function which returns a given number in decimal format based on the number of decimals provided. You can optionally pass in a value a third argument to dictate the maximum number of decimal places used, otherwise the default is `6`.
+To convert a balance to decimal format, you can use the `toDecimal` function which returns a given number in decimal format based on the number of decimals provided. You can optionally pass in a value a third argument to dictate the maximum number of decimal places used, otherwise the default is `6`; and a fourth argument which dictates the [rounding method](https://mikemcl.github.io/big.js/#rm) of the number.
+The `toDecimal` function returns a `Big` number type that you can convert to number or string using its methods `toNumber`, `toFixed`, `toPrecision` and `toExponential`. We recomend using them as `string` since big numbers or numbers with a lot of decimals can lose precision using `number` types
 
 To convert from decimal number back to BigInt, you can use the `toBigInt` function which returns a given number in BigInt format based on the number of decimals provided.
+
+You can also use `hasDecimalOverflow` to make sure that a given number does not have more decimal places than allowed. This is helpful for form inputs.
 
 For example, to convert a balance on Moonbeam from Wei to Glimmer you can use the following code:
 
 ```js
 import { toDecimal, toBigInt } from '@moonbeam-network/xcm-utils';
 
-const balance = toDecimal(3999947500000000000n, 18);
-console.log(balance); // Returns 3.999947
+const balance = toDecimal(3999947500000000000n, 18).toFixed();
+console.log(balance); // Returns '3.999947'
 
-const big = toBigInt(3.999947, 18);
+const big = toBigInt('3.999947', 18);
 console.log(big); // Returns 3999947000000000000n
 ```

--- a/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
@@ -823,7 +823,16 @@ unsubscribe();
 
 ### Utility Functions {: #sdk-utils }
 
-The XCM SDK provides three utility functions: `isXcmSdkDeposit`, `isXcmSdkWithdraw`, and XCM UTILS `toDecimal`, `toBigInt` and `hasDecimalOverflow`.
+There are utility functions in both the XCM SDK and the XCM Utilities packages. The XCM SDK provides the following SDK-related utility functions:
+
+- `isXcmSdkDeposit`
+- `isXcmSdkWithdraw`
+
+And the XCM Utilities package provides the following generic utility functions:
+
+- `toDecimal`
+- `toBigInt`
+- `hasDecimalOverflow`
 
 #### Check if Transfer Data is for a Deposit  {: #deposit-check }
 
@@ -875,8 +884,8 @@ console.log(isXcmSdkDeposit(deposit)) // Returns false
 
 #### Convert Balance to Decimal or BigInt {: #decimals }
 
-To convert a balance to decimal format, you can use the `toDecimal` function which returns a given number in decimal format based on the number of decimals provided. You can optionally pass in a value a third argument to dictate the maximum number of decimal places used, otherwise the default is `6`; and a fourth argument which dictates the [rounding method](https://mikemcl.github.io/big.js/#rm) of the number.
-The `toDecimal` function returns a `Big` number type that you can convert to number or string using its methods `toNumber`, `toFixed`, `toPrecision` and `toExponential`. We recomend using them as `string` since big numbers or numbers with a lot of decimals can lose precision using `number` types
+To convert a balance to decimal format, you can use the `toDecimal` function, which returns a given number in decimal format based on the number of decimals provided. You can optionally pass in a value for a third argument to dictate the maximum number of decimal places used; otherwise, the default is `6`; and a fourth argument that dictates the [rounding method](https://mikemcl.github.io/big.js/#rm){target=_blank} of the number.
+The `toDecimal` function returns a Big number type that you can convert to a number or string using its methods `toNumber`, `toFixed`, `toPrecision`, and `toExponential`. We recommend using them as a string, since big numbers or numbers with a lot of decimals can lose precision when using number types.
 
 To convert from decimal number back to BigInt, you can use the `toBigInt` function which returns a given number in BigInt format based on the number of decimals provided.
 

--- a/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
+++ b/builders/interoperability/xcm/xcm-sdk/xcm-sdk.md
@@ -825,18 +825,18 @@ unsubscribe();
 
 There are utility functions in both the XCM SDK and the XCM Utilities packages. The XCM SDK provides the following SDK-related utility functions:
 
-- `isXcmSdkDeposit`
-- `isXcmSdkWithdraw`
+- [`isXcmSdkDeposit`](#deposit-check)
+- [`isXcmSdkWithdraw`](#withdraw-check)
 
 And the XCM Utilities package provides the following generic utility functions:
 
-- `toDecimal`
-- `toBigInt`
-- `hasDecimalOverflow`
+- [`toDecimal`](#decimals)
+- [`toBigInt`](#decimals)
+- [`hasDecimalOverflow`](#decimals)
 
 #### Check if Transfer Data is for a Deposit  {: #deposit-check }
 
-To determine whether transfer data is for a deposit, you can pass in transfer data to the `isXcmSdkWithdraw` function and a boolean will be returned. If `true` is returned the transfer data is for a deposit, and `false` is returned if it is not.
+To determine whether transfer data is for a deposit, you can pass in transfer data to the `isXcmSdkDeposit` function and a boolean will be returned. If `true` is returned the transfer data is for a deposit, and `false` is returned if it is not.
 
 The following are some examples:
 
@@ -860,7 +860,7 @@ console.log(isXcmSdkDeposit(withdraw)) // Returns false
 
 #### Check if Transfer Data is for a Withdrawal {: #withdraw-check }
 
-To determine whether transfer data is for a withdrawal, you can pass in transfer data to the `isXcmSdkWithdraw()` function and a boolean will be returned. If `true` is returned the transfer data is for a withdrawal, and `false` is returned if it is not.
+To determine whether transfer data is for a withdrawal, you can pass in transfer data to the `isXcmSdkWithdraw` function and a boolean will be returned. If `true` is returned the transfer data is for a withdrawal, and `false` is returned if it is not.
 
 The following are some examples:
 
@@ -889,8 +889,6 @@ The `toDecimal` function returns a Big number type that you can convert to a num
 
 To convert from decimal number back to BigInt, you can use the `toBigInt` function which returns a given number in BigInt format based on the number of decimals provided.
 
-You can also use `hasDecimalOverflow` to make sure that a given number does not have more decimal places than allowed. This is helpful for form inputs.
-
 For example, to convert a balance on Moonbeam from Wei to Glimmer you can use the following code:
 
 ```js
@@ -902,3 +900,5 @@ console.log(balance); // Returns '3.999947'
 const big = toBigInt('3.999947', 18);
 console.log(big); // Returns 3999947000000000000n
 ```
+
+You can also use `hasDecimalOverflow` to make sure that a given number does not have more decimal places than allowed. This is helpful for form inputs.


### PR DESCRIPTION
### Description

Changes around documentation for `toDecimal` function from the `xcm-utils` package

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [x] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [x] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [x] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [x] If images have been added, I have run the `compress-images.py` script to compress the images.
- [x] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [x] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
