### PR TITLE
RPC/WS port changes for client v0.30.0

### DIFF
--- a/.snippets/code/ethers-contract-local/deploy.js
+++ b/.snippets/code/ethers-contract-local/deploy.js
@@ -4,7 +4,7 @@ const contractFile = require('./compile');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/ethers-contract-local/get.js
+++ b/.snippets/code/ethers-contract-local/get.js
@@ -4,7 +4,7 @@ const { abi } = require('./compile');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/ethers-contract-local/increment.js
+++ b/.snippets/code/ethers-contract-local/increment.js
@@ -4,7 +4,7 @@ const { abi } = require('./compile');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/ethers-contract-local/reset.js
+++ b/.snippets/code/ethers-contract-local/reset.js
@@ -4,7 +4,7 @@ const { abi } = require('./compile');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/ethers-tx-local/balances.js
+++ b/.snippets/code/ethers-tx-local/balances.js
@@ -3,7 +3,7 @@ const ethers = require('ethers');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/ethers-tx-local/transaction.js
+++ b/.snippets/code/ethers-tx-local/transaction.js
@@ -3,7 +3,7 @@ const ethers = require('ethers');
 const providerRPC = {
   development: {
     name: 'moonbeam-development',
-    rpc: 'http://localhost:9933',
+    rpc: 'http://localhost:9944',
     chainId: 1281,
   },
   moonbase: {

--- a/.snippets/code/web3-contract-local/deploy.js
+++ b/.snippets/code/web3-contract-local/deploy.js
@@ -2,7 +2,7 @@ const Web3 = require('web3');
 const contractFile = require('./compile');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); // Change to correct network

--- a/.snippets/code/web3-contract-local/get.js
+++ b/.snippets/code/web3-contract-local/get.js
@@ -2,7 +2,7 @@ const Web3 = require('web3');
 const { abi } = require('./compile');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); // Change to correct network

--- a/.snippets/code/web3-contract-local/increment.js
+++ b/.snippets/code/web3-contract-local/increment.js
@@ -2,7 +2,7 @@ const Web3 = require('web3');
 const { abi } = require('./compile');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); //Change to correct network

--- a/.snippets/code/web3-contract-local/reset.js
+++ b/.snippets/code/web3-contract-local/reset.js
@@ -2,7 +2,7 @@ const Web3 = require('web3');
 const { abi } = require('./compile');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); // Change to correct network

--- a/.snippets/code/web3-tx-local/balances.js
+++ b/.snippets/code/web3-tx-local/balances.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); // Change to correct network

--- a/.snippets/code/web3-tx-local/transaction.js
+++ b/.snippets/code/web3-tx-local/transaction.js
@@ -1,7 +1,7 @@
 const Web3 = require('web3');
 
 const providerRPC = {
-  development: 'http://localhost:9933',
+  development: 'http://localhost:9944',
   moonbase: 'https://rpc.api.moonbase.moonbeam.network',
 };
 const web3 = new Web3(providerRPC.development); // Change to correct network

--- a/.snippets/code/web3py-contract/deploy.py
+++ b/.snippets/code/web3py-contract/deploy.py
@@ -2,7 +2,7 @@ from compile import abi, bytecode
 from web3 import Web3
 
 provider_rpc = {
-    'development': 'http://localhost:9933',
+    'development': 'http://localhost:9944',
     'alphanet': 'https://rpc.api.moonbase.moonbeam.network',
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc['development']))  # Change to correct network

--- a/.snippets/code/web3py-contract/get.py
+++ b/.snippets/code/web3py-contract/get.py
@@ -2,7 +2,7 @@ from compile import abi, bytecode
 from web3 import Web3
 
 provider_rpc = {
-    'development': 'http://localhost:9933',
+    'development': 'http://localhost:9944',
     'alphanet': 'https://rpc.api.moonbase.moonbeam.network',
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc["development"]))  # Change to correct network

--- a/.snippets/code/web3py-contract/increment.py
+++ b/.snippets/code/web3py-contract/increment.py
@@ -2,7 +2,7 @@ from compile import abi, bytecode
 from web3 import Web3
 
 provider_rpc = {
-    'development': 'http://localhost:9933',
+    'development': 'http://localhost:9944',
     'alphanet': 'https://rpc.api.moonbase.moonbeam.network',
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc["development"]))  # Change to correct network

--- a/.snippets/code/web3py-contract/reset.py
+++ b/.snippets/code/web3py-contract/reset.py
@@ -2,7 +2,7 @@ from compile import abi, bytecode
 from web3 import Web3
 
 provider_rpc = {
-    'development': 'http://localhost:9933',
+    'development': 'http://localhost:9944',
     'alphanet': 'https://rpc.api.moonbase.moonbeam.network',
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc["development"]))  # Change to correct network

--- a/.snippets/code/web3py-tx/balances.py
+++ b/.snippets/code/web3py-tx/balances.py
@@ -1,7 +1,7 @@
 from web3 import Web3
 
 provider_rpc = {
-    "development": "http://localhost:9933",
+    "development": "http://localhost:9944",
     "alphanet": "https://rpc.api.moonbase.moonbeam.network",
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc["development"]))  # Change to correct network

--- a/.snippets/code/web3py-tx/transaction.py
+++ b/.snippets/code/web3py-tx/transaction.py
@@ -1,7 +1,7 @@
 from web3 import Web3
 
 provider_rpc = {
-    "development": "http://localhost:9933",
+    "development": "http://localhost:9944",
     "alphanet": "https://rpc.api.moonbase.moonbeam.network",
 }
 web3 = Web3(Web3.HTTPProvider(provider_rpc["development"]))  # Change to correct network

--- a/.snippets/text/collators/generate-session-keys.md
+++ b/.snippets/text/collators/generate-session-keys.md
@@ -6,10 +6,10 @@ First, make sure you're [running a collator node](/node-operators/networks/run-a
 
 Next, session keys can be created/rotated by sending an RPC call to the HTTP endpoint with the `author_rotateKeys` method. When you call `author_rotateKeys`, the result is the size of two keys. The response will contain a concatenated Nimbus ID and VRF key. The Nimbus ID will be used to sign blocks and the [VRF](https://wiki.polkadot.network/docs/learn-randomness#vrf){target=_blank} key is required for block production. The concatenated keys will be used to create an association to your H160 account for block rewards to be paid out.
 
-For reference, if your collator's HTTP endpoint is at port `9933`, the JSON-RPC call might look like this:
+For reference, if your collator's HTTP endpoint is at port `9944`, the JSON-RPC call might look like this:
 
 ```
-curl http://127.0.0.1:9933 -H \
+curl http://127.0.0.1:9944 -H \
 "Content-Type:application/json;charset=utf-8" -d \
   '{
     "jsonrpc":"2.0",

--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -6,6 +6,8 @@ title: Full Node Docker Commands for MacOS
 
 For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
 
+For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
+
 ## Moonbeam Full Node {: #moonbeam-full-node } 
 
 ```

--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -11,7 +11,7 @@ For client versions prior to v0.30.0, `--rpc-port` was used to specify the port 
 ## Moonbeam Full Node {: #moonbeam-full-node } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \
@@ -29,7 +29,7 @@ purestake/moonbeam:v0.29.0 \
 ## Moonbeam Collator {: #moonbeam-collator } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \
@@ -46,7 +46,7 @@ purestake/moonbeam:v0.29.0 \
 ## Moonriver Full Node {: #moonriver-full-node } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \
@@ -64,7 +64,7 @@ purestake/moonbeam:v0.29.0 \
 ## Moonriver Collator {: #moonriver-collator } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \
@@ -82,7 +82,7 @@ purestake/moonbeam:v0.29.0 \
 ## Moonbase Alpha Full Node {: #moonbase-alpha-full-node } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \
@@ -100,7 +100,7 @@ purestake/moonbeam:v0.29.0 \
 ## Moonbase Alpha Collator {: #moonbase-alpha-collator } 
 
 ```
-docker run -p 9933:9933 -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
+docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
 purestake/moonbeam:v0.29.0 \
 --base-path=/data \

--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -84,7 +84,7 @@ purestake/moonbeam:v0.29.0 \
 ```
 docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.29.0 \
+purestake/moonbeam:v0.30.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \
@@ -102,7 +102,7 @@ purestake/moonbeam:v0.29.0 \
 ```
 docker run -p 9944:9944 -v "/var/lib/alphanet-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.29.0 \
+purestake/moonbeam:v0.30.0 \
 --base-path=/data \
 --chain alphanet \
 --name="YOUR-NODE-NAME" \

--- a/builders/build/eth-api/debug-trace.md
+++ b/builders/build/eth-api/debug-trace.md
@@ -69,7 +69,7 @@ To change the default values you can add [Additional Flags](/node-operators/netw
 
 For this guide, you will need to have a locally running instance of a Moonbase Alpha tracing node with the `debug`, `txpool`, and `tracing` flags enabled for this guide. You can also adapt the instructions for Moonbeam and Moonriver. 
 
-If you haven't already done so, you can follow the guide on [Running a Tracing Node](/node-operators/networks/tracing-node/){target=_blank}. The RPC HTTP endpoint should be at `http://127.0.0.1:9933`.
+If you haven't already done so, you can follow the guide on [Running a Tracing Node](/node-operators/networks/tracing-node/){target=_blank}. The RPC HTTP endpoint should be at `{{ networks.development.rpc_url }}`.
 
 If you have a running node, you should see a similar terminal log:
 

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -133,10 +133,10 @@ For more information on some of the flags and options used in the example, check
 ```
 ## Connecting Polkadot.js Apps to a Local Moonbeam Node {: #connecting-polkadot-js-apps-to-a-local-moonbeam-node } 
 
-The development node is a Substrate-based node, so you can interact with it using standard Substrate tools. The two provided RPC endpoints are:
+The development node is a Substrate-based node, so you can interact with it using standard Substrate tools. The RPC endpoint for HTTP and WS is:
 
- - **HTTP** - `http://127.0.0.1:9933`
- - **WS** - `ws://127.0.0.1:9944` 
+ - **HTTP** - `{{ networks.development.rpc_url }}`
+ - **WS** - `{{ networks.development.wss_url }}` 
 
 Start by connecting to it with Polkadot.js Apps. Open a browser to: [https://polkadot.js.org/apps/#/explorer](https://polkadot.js.org/apps/#/explorer){target=_blank}. This will open Polkadot.js Apps, which automatically connects to Polkadot MainNet.
 
@@ -242,4 +242,4 @@ Also, included with the development node is a prefunded account used for testing
 For a Moonbeam development node, you can use any of the following block explorers:
 
  - **Substrate API** — [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=ws%3A%2F%2F127.0.0.1%3A9944#/explorer){target=_blank} on WS port `9944`
- - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbeamDevNode){target=_blank} on HTTP port `9933`
+ - **Ethereum API JSON-RPC based** — [Moonbeam Basic Explorer](https://moonbeam-explorer.netlify.app/?network=MoonbeamDevNode){target=_blank} on HTTP port `9944`

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -47,14 +47,14 @@ You can run the Docker image using the following:
 
 === "MacOS"
     ```
-    docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 -p 9933:9933 \
+    docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 \
     purestake/moonbeam:{{ networks.development.build_tag }} \
     --dev --ws-external --rpc-external
     ```
 
 === "Windows"
     ```
-    docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 -p 9933:9933 ^
+    docker run --rm --name {{ networks.development.container_name }} -p 9944:9944 ^
     purestake/moonbeam:{{ networks.development.build_tag }} ^
     --dev --ws-external --rpc-external
     ```

--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -210,8 +210,8 @@ Options accept an argument to the right side of the option. For example:
 
 - **`-l <log pattern>` or `--log <log pattern>`** - sets a custom logging filter. The syntax for the log pattern is `<target>=<level>`. For example, to print all of the JSON RPC logs, the command would look like this: `-l json=trace`
 - **`--sealing <interval>`** - when blocks should be sealed in the dev service. Accepted arguments for interval: `instant`, `manual`, or a number representing the timer interval in milliseconds (for example, `6000` will have the node produce blocks every 6 seconds). The default is `instant`
-- **`--rpc-port <port>`** - sets the HTTP RPC server TCP port. Accepts a port as the argument
-- **`--ws-port <port>`**: sets the WebSockets RPC server TCP port. Accepts a port as the argument
+- **`--rpc-port <port>`** - *deprecated as of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, use `--ws-port` for HTTP and WS connections instead* - sets the HTTP RPC server TCP port. Accepts a port as the argument
+- **`--ws-port <port>`**: sets the WebSockets RPC server TCP port. As of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, the WS port is a unified port for both HTTP and WS connections. Accepts a port as the argument
 
 For a complete list of flags and options, spin up your Moonbeam development node with `--help` added to the end of the command.
 

--- a/node-operators/networks/collators/account-management.md
+++ b/node-operators/networks/collators/account-management.md
@@ -89,7 +89,7 @@ You can check the current on-chain mappings for a specific collator or you can a
 To use the `mappingWithDeposit` method to check the mapping for a specific collator, you'll need to get the Nimbus ID. To do so, you can take the first 64 hexadecimal characters of the concatenated public keys to get the Nimbus ID. To verify that the Nimbus ID is correct, you can run the following command with the first 64 characters passed into the `params` array:
 
 ```
-curl http://127.0.0.1:9933 -H "Content-Type:application/json;charset=utf-8" -d   '{
+curl {{ networks.development.rpc_url }} -H "Content-Type:application/json;charset=utf-8" -d   '{
   "jsonrpc":"2.0",
   "id":1,
   "method":"author_hasKey",

--- a/node-operators/networks/run-a-node/docker.md
+++ b/node-operators/networks/run-a-node/docker.md
@@ -71,6 +71,8 @@ If you're using MacOS, there are adapted [code snippets](https://www.github.com/
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
 
+    For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
+
 ### Full Node {: #full-node } 
 
 === "Moonbeam"
@@ -197,7 +199,7 @@ Once Docker pulls the necessary images, your full Moonbeam (or Moonriver) node w
     You can specify a custom Prometheus port with the `--prometheus-port XXXX` flag (replacing `XXXX` with the actual port number). This is possible for both the parachain and embedded relay chain.
 
 ```
-docker run -p {{ networks.relay_chain.p2p }}:{{ networks.relay_chain.p2p }} -p {{ networks.parachain.p2p }}:{{ networks.parachain.p2p }} -p {{ networks.parachain.rpc }}:{{ networks.parachain.rpc }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} #rest of code goes here
+docker run -p {{ networks.relay_chain.p2p }}:{{ networks.relay_chain.p2p }} -p {{ networks.parachain.p2p }}:{{ networks.parachain.p2p }} -p {{ networks.parachain.ws }}:{{ networks.parachain.ws }} # rest of code goes here
 ```
 
 During the syncing process, you will see messages from both the embedded relay chain and the parachain (without a tag). These messages display a target block (live network state) and a best block (local node synced state).

--- a/node-operators/networks/run-a-node/flags.md
+++ b/node-operators/networks/run-a-node/flags.md
@@ -17,8 +17,9 @@ This guide will cover some of the most common flags and show you how to access a
 
 - **`--collator`** - enables collator mode for collator candidates and, if eligible, allows the node to actively participate in block production
 - **`--port`** - specifies the peer-to-peer protocol TCP port. The default port for parachains is `{{ networks.parachain.p2p }}` and `{{ networks.relay_chain.p2p }}` for the embedded relay chain
-- **`--rpc-port`**  - specifies the HTTP RPC server TCP port. The default port for parachains is `{{ networks.parachain.rpc }}`  and `{{ networks.relay_chain.rpc }}` for the embedded relay chain
-- **`--ws-port`** - specifies the WebSockets RPC server TCP port. The default port for parachains is `{{ networks.parachain.ws }}`  and `{{ networks.relay_chain.ws }}` for the embedded relay chain
+- **`--rpc-port`** - *deprecated as of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, use `--ws-port` for HTTP and WS connections instead* - specifies the HTTP RPC server TCP port. The default port for parachains is `{{ networks.parachain.rpc }}`  and `{{ networks.relay_chain.rpc }}` for the embedded relay chain
+- **`--ws-port`** - specifies the WebSockets RPC server TCP port. As of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, the WS port is a unified port for both HTTP and WS connections. The default port for parachains is `{{ networks.parachain.ws }}`  and `{{ networks.relay_chain.ws }}` for the embedded relay chain
+- **`--ws-max-connections`** - specifies the maximum number of WS RPC server connections. As of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, this flag adjusts the combined HTTP and WS connection limit
 - **`--execution`** - specifies the execution strategy that should be used by all execution contexts. The Substrate runtime is compiled into a native executable which is included locally as part of the node and a WebAssembly (Wasm) binary that is stored on-chain. The available options are:
     - **`native`** - only execute with the native build
     - **`wasm`** - only execute with the Wasm build

--- a/node-operators/networks/run-a-node/overview.md
+++ b/node-operators/networks/run-a-node/overview.md
@@ -61,13 +61,15 @@ As stated before, the relay/parachain nodes will listen on multiple ports. The d
 
 The only ports that need to be open for incoming traffic are those designated for P2P. **Collators must not have RPC or WS ports opened**.
 
+!!! note
+    As of [client v0.30.0](https://github.com/PureStake/moonbeam/releases/tag/v0.30.0){target=_blank}, the HTTP RPC endpoint at port {{ networks.parachain.rpc }} has been deprecated. The WS RPC endpoint at port {{ networks.parachain.ws }} should be used for both HTTP and WS connections.
+
 ### Default Ports for a Parachain Full-Node {: #default-ports-for-a-parachain-full-node } 
 
 |  Description   |                Port                 |
 |:--------------:|:-----------------------------------:|
 |    **P2P**     | {{ networks.parachain.p2p }} (TCP)  |
-|    **RPC**     |    {{ networks.parachain.rpc }}     |
-|     **WS**     |     {{ networks.parachain.ws }}     |
+|  **RPC & WS**  |     {{ networks.parachain.ws }}     |
 | **Prometheus** | {{ networks.parachain.prometheus }} |
 
 ### Default Ports of Embedded Relay Chain {: #default-ports-of-embedded-relay-chain } 
@@ -75,8 +77,7 @@ The only ports that need to be open for incoming traffic are those designated fo
 |  Description   |                 Port                  |
 |:--------------:|:-------------------------------------:|
 |    **P2P**     | {{ networks.relay_chain.p2p }} (TCP)  |
-|    **RPC**     |    {{ networks.relay_chain.rpc }}     |
-|     **WS**     |     {{ networks.relay_chain.ws }}     |
+|  **RPC & WS**  |     {{ networks.relay_chain.ws }}     |
 | **Prometheus** | {{ networks.relay_chain.prometheus }} |
 
 ## Installation {: #installation }

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -198,6 +198,7 @@ The next step is to create the systemd configuration file. If you are setting up
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    
     For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 ### Full Node {: #full-node } 

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -198,6 +198,7 @@ The next step is to create the systemd configuration file. If you are setting up
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 ### Full Node {: #full-node } 
 
@@ -218,7 +219,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -230,7 +230,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -256,7 +255,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -268,7 +266,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -294,7 +291,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -306,7 +302,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -338,7 +333,6 @@ The next step is to create the systemd configuration file. If you are setting up
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
          --collator \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -349,7 +343,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -376,7 +369,6 @@ The next step is to create the systemd configuration file. If you are setting up
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
          --collator \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -387,7 +379,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -414,7 +405,6 @@ The next step is to create the systemd configuration file. If you are setting up
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
          --collator \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
@@ -425,7 +415,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -219,8 +219,6 @@ The next step is to create the systemd configuration file. If you are setting up
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
@@ -230,8 +228,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonbeam.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -255,8 +251,6 @@ The next step is to create the systemd configuration file. If you are setting up
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
@@ -266,8 +260,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonriver.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -291,8 +283,6 @@ The next step is to create the systemd configuration file. If you are setting up
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --state-pruning=archive \
@@ -302,8 +292,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonbase.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 
@@ -333,8 +321,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
          --collator \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --trie-cache-size 0 \
@@ -343,8 +329,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonbeam.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -369,8 +353,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
          --collator \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --trie-cache-size 0 \
@@ -379,8 +361,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonriver.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -405,8 +385,6 @@ The next step is to create the systemd configuration file. If you are setting up
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
          --collator \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --wasm-execution compiled \
          --trie-cache-size 0 \
@@ -415,8 +393,6 @@ The next step is to create the systemd configuration file. If you are setting up
          --chain {{ networks.moonbase.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -275,8 +275,6 @@ The next step is to create the systemd configuration file, you'll need to:
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
          --trie-cache-size 0 \
@@ -288,8 +286,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --chain {{ networks.moonbeam.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -313,8 +309,6 @@ The next step is to create the systemd configuration file, you'll need to:
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
          --trie-cache-size 0 \
@@ -326,8 +320,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --chain {{ networks.moonriver.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
     
@@ -351,8 +343,6 @@ The next step is to create the systemd configuration file, you'll need to:
     SyslogFacility=local7
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
-         --port {{ networks.parachain.p2p }} \
-         --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
          --trie-cache-size 0 \
@@ -364,8 +354,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --chain {{ networks.moonbase.chain_spec }} \
          --name "YOUR-NODE-NAME" \
          -- \
-         --port {{ networks.relay_chain.p2p }} \
-         --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -92,6 +92,7 @@ Now, execute the docker run command. Note that you have to:
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 The complete command for running a tracing node is as follows:
 

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -254,6 +254,7 @@ The next step is to create the systemd configuration file, you'll need to:
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 === "Moonbeam"
     ```
@@ -272,7 +273,6 @@ The next step is to create the systemd configuration file, you'll need to:
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbeam.node_directory }}/{{ networks.moonbeam.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
@@ -286,7 +286,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -312,7 +311,6 @@ The next step is to create the systemd configuration file, you'll need to:
     KillSignal=SIGHUP
     ExecStart={{ networks.moonriver.node_directory }}/{{ networks.moonriver.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
@@ -326,7 +324,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"
@@ -352,7 +349,6 @@ The next step is to create the systemd configuration file, you'll need to:
     KillSignal=SIGHUP
     ExecStart={{ networks.moonbase.node_directory }}/{{ networks.moonbase.binary_name }} \
          --port {{ networks.parachain.p2p }} \
-         --rpc-port {{ networks.parachain.rpc }} \
          --ws-port {{ networks.parachain.ws }} \
          --execution wasm \
          --state-pruning=archive \
@@ -366,7 +362,6 @@ The next step is to create the systemd configuration file, you'll need to:
          --name "YOUR-NODE-NAME" \
          -- \
          --port {{ networks.relay_chain.p2p }} \
-         --rpc-port {{ networks.relay_chain.rpc }} \
          --ws-port {{ networks.relay_chain.ws }} \
          --execution wasm \
          --name="YOUR-NODE-NAME (Embedded Relay)"

--- a/node-operators/networks/tracing-node.md
+++ b/node-operators/networks/tracing-node.md
@@ -92,6 +92,7 @@ Now, execute the docker run command. Note that you have to:
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    
     For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 The complete command for running a tracing node is as follows:
@@ -255,6 +256,7 @@ The next step is to create the systemd configuration file, you'll need to:
 
 !!! note
     For client versions prior to v0.27.0, the `--state-pruning` flag was named `--pruning`.
+    
     For client versions prior to v0.30.0, `--rpc-port` was used to specify the port for HTTP connections and `--ws-port` was used to specify the port for WS connections. As of client v0.30.0, the `--ws-port` flag is for both HTTP and WS connections.
 
 === "Moonbeam"

--- a/variables.yml
+++ b/variables.yml
@@ -1,7 +1,7 @@
 networks:
   development:
     build_tag: v0.30.0
-    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
+    tracing_tag: purestake/moonbeam-tracing:v0.30.0-2201-latest
     rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
@@ -15,9 +15,9 @@ networks:
     hex_chain_id: '0x507'
     chain_spec: alphanet
     block_explorer: https://moonbase.moonscan.io/
-    parachain_release_tag: v0.29.0 # must be in this exact format for links to work
-    parachain_sha256sum: afc7f4cf869fea6af3e4d104b5e99b764df6baca8b6157cc4e1fd8a345e75623
-    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
+    parachain_release_tag: v0.30.0 # must be in this exact format for links to work
+    parachain_sha256sum: b0ee08ab990c38c1aba1b0c9f141bfc9488f1af9a3ef2996af3ca79cbf32dbd9
+    tracing_tag: purestake/moonbeam-tracing:v0.30.0-2201-latest
     gas_block: 15M
     gas_tx: 12.995M
     node_directory: /var/lib/alphanet-data

--- a/variables.yml
+++ b/variables.yml
@@ -1,8 +1,8 @@
 networks:
   development:
-    build_tag: v0.29.0
+    build_tag: v0.30.0
     tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
-    rpc_url: http://127.0.0.1:9933
+    rpc_url: http://127.0.0.1:9944
     wss_url: ws://127.0.0.1:9944
     chain_id: 1281
     hex_chain_id: '0x501'


### PR DESCRIPTION
### Description

This PR bumps the client version to v0.30.0 for Moonbase Alpha and updates node commands per changes made in client v0.30.0:

- `--rpc-port` has been deprecated in favor of `--ws-port`
- `--ws-port` now specifies a unified port for HTTP and WS connections

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done

