### PR TITLE
fix curl command typo in tx-fees

### DIFF
--- a/builders/get-started/eth-compare/tx-fees.md
+++ b/builders/get-started/eth-compare/tx-fees.md
@@ -200,7 +200,7 @@ The following curl example will return the gas information of the last 10 blocks
 
 === "Moonbeam"
     ```sh
-    curl --location 
+    curl --location \
          --request POST '{{ networks.moonbeam.rpc_url }}' \
          --header 'Content-Type: application/json' \
          --data-raw '{
@@ -212,7 +212,7 @@ The following curl example will return the gas information of the last 10 blocks
     ```
 === "Moonriver"
     ```sh
-    curl --location 
+    curl --location \
          --request POST '{{ networks.moonriver.rpc_url }}' \
          --header 'Content-Type: application/json' \
          --data-raw '{
@@ -224,7 +224,7 @@ The following curl example will return the gas information of the last 10 blocks
     ```
 === "Moonbase Alpha"
     ```sh
-    curl --location 
+    curl --location \
          --request POST '{{ networks.moonbase.rpc_url }}' \
          --header 'Content-Type: application/json' \
          --data-raw '{
@@ -236,7 +236,7 @@ The following curl example will return the gas information of the last 10 blocks
     ```
 === "Moonbeam Dev Node"
     ```sh
-    curl --location 
+    curl --location \
          --request POST '{{ networks.development.rpc_url }}' \
          --header 'Content-Type: application/json' \
          --data-raw '{

--- a/learn/features/eth-compatibility.md
+++ b/learn/features/eth-compatibility.md
@@ -45,13 +45,13 @@ The EVM executes Ethereum smart contract bytecode, of which is typically written
 
 Inside of the EVM are standard H160 Ethereum-style accounts, and they have associated data such as the balance and nonce. All of the accounts in the EVM are backed by a Substrate account type, which is configurable. Moonbeam has configured the Substrate account type to be a non-standard H160 account to be fully compatibile with Ethereum. As such, you only need a single account to interact with the Substrate runtime and the EVM. For more information on Moonbeam's account system, please refer to the [Unified Accounts](/learn/features/unified-accounts/){target=_blank} page.
 
-Without a unified accounts system, a mapped Substrate account can call the EVM pallet to deposit or withdraw balance from the Substrate-base currency into a different balance managed and used by the EVM pallet. Once a balance exists, smart contracts can be created and interacted with. 
+With a unified accounts system, a mapped Substrate account can call the EVM pallet to deposit or withdraw balance from the Substrate-base currency into a different balance managed and used by the EVM pallet. Once a balance exists, smart contracts can be created and interacted with. 
 
 The EVM pallet can also be configured so that no dispatchable calls can cause EVM execution with the exception being from other pallets in the runtime. Moonbeam is configured this way with pallet Ethereum having sole responsibility of EVM execution. Using pallet Ethereum enables EVM interactions through the Ethereum API. 
 
 If a blockchain doesn't need Ethereum emulation and only needs EVM execution, Substrate uses its account model fully and signs transactions on behalf of EVM accounts. However, in this model Ethereum RPCs are not available, and DApps must write their frontend using the Substrate API.
 
-The EVM pallet should produce nearly identical execution results compared to Ethereum, such as gas cost and balance changes. However, there are some differences. Please refer to the [EVM module vs Ethereum network](https://paritytech.github.io/frontier/frame/evm.html#execution-lifecycle) section of the Frontier EVM Pallet documentation for more information.
+The EVM pallet should produce nearly identical execution results compared to Ethereum, such as gas cost and balance changes. However, there are some differences. Please refer to the [EVM module vs Ethereum network](https://paritytech.github.io/frontier/frame/evm.html#execution-lifecycle){target=_blank} section of the Frontier EVM Pallet documentation for more information.
 
 There are also some [precompiles](https://github.com/paritytech/frontier/tree/4c05c2b09e71336d6b11207e6d12e486b4d2705c#evm-pallet-precompiles){target=_blank} that can be used alongside the EVM pallet that extend the functionality of the EVM. Moonbeam uses the following EVM precompiles:
 
@@ -68,6 +68,6 @@ You can find an overview of most of these precompiles on the [Ethereum MainNet P
 
 The [Ethereum pallet](https://paritytech.github.io/frontier/frame/ethereum.html){target=_blank} is responsible for handling blocks and transaction receipts and statuses. It enables sending and receiving Ethereum-formatted data to and from Moonbeam by storing an Ethereum-style block and it's associated transaction hashes in the Substrate runtime.
 
-When a user submits a raw Ethereum transaction, it gets converted into a Substrate transaction through the pallet Ethereum's `transact` extrinsic. Using the Ethereum pallet as the sole executor of the EVM pallet, forces all of the data to be stored and transacted with in an Ethereum-compatible way. This enables block explorers such as [Moonscan](/builders/get-started/explorers#moonscan), which is built by Etherscan, to be able to index block data.
+When a user submits a raw Ethereum transaction, it gets converted into a Substrate transaction through the pallet Ethereum's `transact` extrinsic. Using the Ethereum pallet as the sole executor of the EVM pallet, forces all of the data to be stored and transacted with in an Ethereum-compatible way. This enables block explorers such as [Moonscan](/builders/get-started/explorers#moonscan){target=_blank}, which is built by Etherscan, to be able to index block data.
 
 Along with support for Ethereum-style data, the Ethereum pallet combined with the [RPC module](https://github.com/paritytech/frontier/tree/master/client/rpc){target=_blank} provides RPC support. This enables usage of [basic Ethereum JSON-RPC methods](/builders/get-started/eth-compare/rpc-support#basic-ethereum-json-rpc-methods){target=_blank} which ultimately allows existing Ethereum DApps to be deployed to Moonbeam with minimal changes. 


### PR DESCRIPTION
### Description

A minor fix for the curl commands in tx-fees page.

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
