### PR TITLE
hide feedback widget on index pages

### DIFF
--- a/builders/build/eth-api/dev-env/index.md
+++ b/builders/build/eth-api/dev-env/index.md
@@ -4,6 +4,7 @@ description: Learn how to use Ethereum tools such as Remix, OpenZeppelin, Hardha
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Ethereum Development Environments</h1>

--- a/builders/build/eth-api/dev-env/openzeppelin/index.md
+++ b/builders/build/eth-api/dev-env/openzeppelin/index.md
@@ -4,6 +4,7 @@ description: Use OpenZeppelin contracts and libraries, the Contract Wizard, or D
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>OpenZeppelin</h1>

--- a/builders/build/eth-api/index.md
+++ b/builders/build/eth-api/index.md
@@ -4,6 +4,7 @@ description: Learn how to use the Ethereum API when developing on Moonbeam. This
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Ethereum API</h1>

--- a/builders/build/eth-api/libraries/index.md
+++ b/builders/build/eth-api/libraries/index.md
@@ -4,6 +4,7 @@ description: Learn how to use JavaScript or Python Ethereum libraries such as Et
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Ethereum Libraries</h1>

--- a/builders/build/eth-api/verify-contracts/index.md
+++ b/builders/build/eth-api/verify-contracts/index.md
@@ -4,6 +4,7 @@ description: Learn how to verify your Solidity smart contracts deployed to Moonb
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Verify Smart Contracts</h1>

--- a/builders/build/index.md
+++ b/builders/build/index.md
@@ -4,6 +4,7 @@ description: Guides for learning how to interact with the Ethereum & Substrate A
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Build</h1>

--- a/builders/build/substrate-api/index.md
+++ b/builders/build/substrate-api/index.md
@@ -4,6 +4,7 @@ description: Learn how to interact with the Substrate API when developing on Moo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Substrate API</h1>

--- a/builders/get-started/eth-compare/index.md
+++ b/builders/get-started/eth-compare/index.md
@@ -4,6 +4,7 @@ description: Dive into some of the key differences between Moonbeam, an Ethereum
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Moonbeam vs Ethereum</h1>

--- a/builders/get-started/index.md
+++ b/builders/get-started/index.md
@@ -4,6 +4,7 @@ description: Everything you need to know to get started developing, deploying, a
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Get Started</h1>

--- a/builders/get-started/networks/index.md
+++ b/builders/get-started/networks/index.md
@@ -4,6 +4,7 @@ description: Learn how to get started developing on a Moonbeam development node,
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Networks</h1>

--- a/builders/get-started/networks/layer2/index.md
+++ b/builders/get-started/networks/layer2/index.md
@@ -4,6 +4,7 @@ description: Learn how to use the Ethereum API when developing on Moonbeam. This
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Boba Layer 2</h1>

--- a/builders/index.md
+++ b/builders/index.md
@@ -4,6 +4,7 @@ description: Guides for getting started and developing on Moonbeam. Learn how to
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Builders</h1>

--- a/builders/integrations/analytics/index.md
+++ b/builders/integrations/analytics/index.md
@@ -4,6 +4,7 @@ description: Analyze on-chain smart contract data by building charts and dashboa
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Analytics</h1>

--- a/builders/integrations/index.md
+++ b/builders/integrations/index.md
@@ -4,6 +4,7 @@ description: Learn about the available integrations on Moonbeam to ease your DAp
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Integrations</h1>

--- a/builders/integrations/indexers/index.md
+++ b/builders/integrations/indexers/index.md
@@ -4,6 +4,7 @@ description: Learn how to build your own API or consume API endpoints from one o
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Indexers and APIs</h1>

--- a/builders/integrations/oracles/index.md
+++ b/builders/integrations/oracles/index.md
@@ -4,6 +4,7 @@ description: Learn how to add an oracle such as ChainLink, Band, or Razor Networ
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Oracles</h1>

--- a/builders/integrations/relayers/index.md
+++ b/builders/integrations/relayers/index.md
@@ -4,6 +4,7 @@ description: Learn how to use transaction relayers for gasless transactions and 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Relayers</h1>

--- a/builders/integrations/wallets/index.md
+++ b/builders/integrations/wallets/index.md
@@ -4,6 +4,7 @@ description: Learn how to add wallet integrations, such as MetaMask and WalletCo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Wallets</h1>

--- a/builders/interoperability/index.md
+++ b/builders/interoperability/index.md
@@ -4,6 +4,7 @@ description: Learn about interoperability on Moonbeam by diving into how cross-c
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Interoperability</h1>

--- a/builders/interoperability/protocols/index.md
+++ b/builders/interoperability/protocols/index.md
@@ -4,6 +4,7 @@ description: Learn about the cross-chain protocols you can use to securely commu
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Cross-Chain Protocols</h1>

--- a/builders/interoperability/xcm/index.md
+++ b/builders/interoperability/xcm/index.md
@@ -4,6 +4,7 @@ description: An overview of how cross-consensus messaging (XCM) works, and how d
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>XCM Interoperability</h1>

--- a/builders/interoperability/xcm/xc20/index.md
+++ b/builders/interoperability/xcm/xc20/index.md
@@ -4,6 +4,7 @@ description: Learn about cross chain assets, referred to as XC-20s, and how to i
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>XC-20s</h1>

--- a/builders/interoperability/xcm/xcm-sdk/index.md
+++ b/builders/interoperability/xcm/xcm-sdk/index.md
@@ -4,6 +4,7 @@ description: Guides on the available methods and interfaces in the Moonbeam XCM 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>XCM SDK</h1>

--- a/builders/pallets-precompiles/index.md
+++ b/builders/pallets-precompiles/index.md
@@ -4,6 +4,7 @@ description: Guides for learning how to interact with the Ethereum & Substrate A
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Pallets & Precompiles</h1>

--- a/builders/pallets-precompiles/pallets/index.md
+++ b/builders/pallets-precompiles/pallets/index.md
@@ -4,6 +4,7 @@ description: Learn about the pallets available on Moonbeam and how to interact w
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Substrate Pallets</h1>

--- a/builders/pallets-precompiles/precompiles/index.md
+++ b/builders/pallets-precompiles/precompiles/index.md
@@ -4,6 +4,7 @@ description: A list of guides for interacting with precompiled contracts on Moon
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Solidity Precompiles</h1>

--- a/learn/dapps-list/index.md
+++ b/learn/dapps-list/index.md
@@ -4,6 +4,7 @@ description: Learn about some of the available listing services for DApps on Moo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>DApps Lists</h1>

--- a/learn/features/index.md
+++ b/learn/features/index.md
@@ -4,6 +4,7 @@ description: Learn about some of the main features on Moonbeam, including Ethere
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Features</h1>

--- a/learn/index.md
+++ b/learn/index.md
@@ -4,6 +4,7 @@ description: Learn all about Moonbeam, including basics about the Ethereum compa
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Learn</h1>

--- a/learn/platform/index.md
+++ b/learn/platform/index.md
@@ -4,6 +4,7 @@ description: Learn about the Moonbeam smart contract platform, including the Moo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Platform</h1>

--- a/learn/platform/networks/index.md
+++ b/learn/platform/networks/index.md
@@ -4,6 +4,7 @@ description: Learn the basics about each of the Moonbeam networks, including Moo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Networks</h1>

--- a/node-operators/index.md
+++ b/node-operators/index.md
@@ -4,6 +4,7 @@ description: Learn how to become a node operator on Moonbeam, including running 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Node Operators</h1>

--- a/node-operators/indexer-nodes/index.md
+++ b/node-operators/indexer-nodes/index.md
@@ -4,6 +4,7 @@ description: Learn how to run an indexer node, such as a Graph node, on Moonbeam
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Indexer Nodes</h1>

--- a/node-operators/networks/collators/index.md
+++ b/node-operators/networks/collators/index.md
@@ -4,6 +4,7 @@ description: Learn how to be a collator and produce blocks on Moonbeam, includin
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Collators</h1>

--- a/node-operators/networks/index.md
+++ b/node-operators/networks/index.md
@@ -4,6 +4,7 @@ description: Learn how to spin up a full, tracing, or collator node on Moonbeam,
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Networks</h1>

--- a/node-operators/networks/run-a-node/index.md
+++ b/node-operators/networks/run-a-node/index.md
@@ -4,6 +4,7 @@ description: Learn how to run a full Parachain node on any of the Moonbeam netwo
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Run a Node</h1>

--- a/node-operators/oracle-nodes/index.md
+++ b/node-operators/oracle-nodes/index.md
@@ -4,6 +4,7 @@ description: Run an oracle node, such as a ChainLink node, on Moonbeam and provi
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Oracle Nodes</h1>

--- a/tokens/connect/index.md
+++ b/tokens/connect/index.md
@@ -4,6 +4,7 @@ description: Learn about some of the supported wallets available for Moonbeam, a
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Connect to Moonbeam</h1>

--- a/tokens/connect/ledger/index.md
+++ b/tokens/connect/ledger/index.md
@@ -4,6 +4,7 @@ description: Learn how to use your Ledger hardware wallet to sign transactions o
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Ledger</h1>

--- a/tokens/governance/index.md
+++ b/tokens/governance/index.md
@@ -4,6 +4,7 @@ description: Learn how to participate in Moonbeam's on-chain governance, includi
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Governance</h1>

--- a/tokens/governance/proposals/index.md
+++ b/tokens/governance/proposals/index.md
@@ -4,6 +4,7 @@ description: Learn how to participate in Moonbeam's governance system by followi
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Submit a Democracy Proposal</h1>

--- a/tokens/governance/voting/index.md
+++ b/tokens/governance/voting/index.md
@@ -4,6 +4,7 @@ description: Participate in Moonbeam's governance system by following step-by-st
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Vote on a Proposal</h1>

--- a/tokens/index.md
+++ b/tokens/index.md
@@ -4,6 +4,7 @@ description: A series of guides for using and managing your GLMR & MOVR tokens, 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Tokens</h1>

--- a/tokens/manage/index.md
+++ b/tokens/manage/index.md
@@ -4,6 +4,7 @@ description: Learn how to manage and secure your account on Moonbeam by creating
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Account Management</h1>

--- a/tokens/staking/index.md
+++ b/tokens/staking/index.md
@@ -4,6 +4,7 @@ description: Learn how to delegate collator candidates and stake your GLMR and M
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Staking</h1>

--- a/tutorials/eth-api/index.md
+++ b/tutorials/eth-api/index.md
@@ -4,6 +4,7 @@ description: Check out these tutorials to learn how to use the Ethereum API and 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Ethereum API</h1>

--- a/tutorials/index.md
+++ b/tutorials/index.md
@@ -4,6 +4,7 @@ description: Dive into the Moonbeam smart contract platform through this compile
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 <h1 class='subsection-title'>Tutorials</h1>

--- a/tutorials/interoperability/index.md
+++ b/tutorials/interoperability/index.md
@@ -4,6 +4,7 @@ description: A list of tutorials related to Moonbeam an its connected contracts 
 template: main.html
 hide: 
  - toc
+ - feedback
 ---
 
 


### PR DESCRIPTION
### Description

Hides the feedback widget on index pages so we are only collecting feedback on page with content.

Goes with mkdocs PR: https://github.com/PureStake/moonbeam-mkdocs/pull/108