### PR TITLE
update polkadot xcm fees for polkadot v0.9.37

### DIFF
--- a/builders/interoperability/xcm/fees.md
+++ b/builders/interoperability/xcm/fees.md
@@ -79,12 +79,12 @@ Although Polkadot doesn't currently use database weight units to calculate costs
 
 |                                                                     Database                                                                     |                     Read                      |                     Write                      |
 |:------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------:|:----------------------------------------------:|
-| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
+| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
 
 With the instruction weight cost established, you can calculate the cost of each instruction in DOT. 
 
-In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
+In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.37/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
 
 Therefore, to calculate the cost of executing an XCM instruction, you can use the following formula:
 

--- a/builders/interoperability/xcm/fees.md
+++ b/builders/interoperability/xcm/fees.md
@@ -79,12 +79,12 @@ Although Polkadot doesn't currently use database weight units to calculate costs
 
 |                                                                     Database                                                                     |                     Read                      |                     Write                      |
 |:------------------------------------------------------------------------------------------------------------------------------------------------:|:---------------------------------------------:|:----------------------------------------------:|
-| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
-|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
+| [RocksDB (default)](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/rocksdb_weights.rs){target=_blank} | {{ networks.polkadot.rocks_db.read_weight }}  | {{ networks.polkadot.rocks_db.write_weight }}  |
+|     [ParityDB](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/paritydb_weights.rs){target=_blank}     | {{ networks.polkadot.parity_db.read_weight }} | {{ networks.polkadot.parity_db.write_weight }} |
 
 With the instruction weight cost established, you can calculate the cost of each instruction in DOT. 
 
-In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L56){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.34/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
+In Polkadot, the [`ExtrinsicBaseWeight`](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/weights/extrinsic_weights.rs#L55){target=_blank} is set to `{{ networks.polkadot.extrinsic_base_weight.display }}` which is [mapped to 1/10th](https://github.com/paritytech/polkadot/blob/v0.9.36/runtime/polkadot/constants/src/lib.rs#L88){targer=blank} of a cent. Where 1 cent is `10^10 / 100`. 
 
 Therefore, to calculate the cost of executing an XCM instruction, you can use the following formula:
 

--- a/variables.yml
+++ b/variables.yml
@@ -970,21 +970,21 @@ networks:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
-      planck_dot_weight: 0.10216174247
-      planck_dot_cost: 102161742.47
-      dot_cost: 0.01021617424
+      planck_dot_weight: 0.10535853509
+      planck_dot_cost: 105358535.09
+      dot_cost: 0.0105358535
     xcm_message:
       transfer:
         weight: 4,000,000,000
-        cost: 0.04086469696
+        cost: 0.042143414
       transact:
         weight: 3,000,000,000
         numbers_only: 3000000000
         planck_dot_cost: 362078329.611
         dot_cost: 0.0362078329611
     extrinsic_base_weight:
-      display: 97,884,000
-      numbers_only: 97884000
+      display: 94,914,000
+      numbers_only: 94914000
   kusama:
     rocks_db:
       read_weight: 25,000,000

--- a/variables.yml
+++ b/variables.yml
@@ -965,26 +965,26 @@ networks:
       write_weight: 83,471,000
     parity_db:
       read_weight: 11,826,000
-      write_weight: 30,052,000
+      write_weight: 38,052,000
     xcm_instructions:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
-      planck_dot_weight: 0.11735436323
-      planck_dot_cost: 117354363.23
-      dot_cost: 0.01173543632
+      planck_dot_weight: 0.10216174247
+      planck_dot_cost: 102161742.47
+      dot_cost: 0.01021617424
     xcm_message:
       transfer:
         weight: 4,000,000,000
-        cost: 0.04694174528
+        cost: 0.04086469696
       transact:
         weight: 3,000,000,000
         numbers_only: 3000000000
         planck_dot_cost: 362078329.611
         dot_cost: 0.0362078329611
     extrinsic_base_weight:
-      display: 85,212,000
-      numbers_only: 85212000
+      display: 97,884,000
+      numbers_only: 97884000
   kusama:
     rocks_db:
       read_weight: 25,000,000

--- a/variables.yml
+++ b/variables.yml
@@ -970,18 +970,18 @@ networks:
       weight:
         display: 1,000,000,000
         numbers_only: 1000000000
-      planck_dot_weight: 0.10535853509
-      planck_dot_cost: 105358535.09
+      planck_dot_weight: 0.105358535
+      planck_dot_cost: 105358535
       dot_cost: 0.0105358535
     xcm_message:
       transfer:
         weight: 4,000,000,000
-        cost: 0.042143414
+        cost: 0.0421434140
       transact:
         weight: 3,000,000,000
         numbers_only: 3000000000
-        planck_dot_cost: 362078329.611
-        dot_cost: 0.0362078329611
+        planck_dot_cost: 31607560500
+        dot_cost: 0.0316075605
     extrinsic_base_weight:
       display: 94,914,000
       numbers_only: 94914000


### PR DESCRIPTION
### Description

Update the XCM Fees page for Polkadot v0.9.36
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/238
