### PR TITLE
fix a small typo

### DIFF
--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -150,7 +150,7 @@ For more information, you can review the [relative Frontier PR on GitHub](https:
 
 #### Incorrect Handling of EIP-1559 Gas Fees {: #incorrect-gas-fees-eip1559 }
 
-With the introduction of EIP-1559 support, the logic for handling `maxFeePerGas` and `maxPriorityFeePerGas` was implemented incorrectly, and as a result, the `maxPriorityFee` was added to the `baseFee` even if the total amount was over the `maxFeePerGas`. 
+With the introduction of EIP-1559 support, the logic for handling `maxFeePerGas` and `maxPriorityFeePerGas` was implemented incorrectly, and as a result, the `maxPriorityFeePerGas` was added to the `baseFee` even if the total amount was over the `maxFeePerGas`. 
 
 This bug existed during the following runtimes and block ranges:
 


### PR DESCRIPTION
### Description

fix a small typo. maxPriorityFee -> maxPriorityFeePerGas

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
- [ ] If pages have been moved around, I have created an additional PR in `moonbeam-mkdocs` to update redirects
- [ ] If pages have been moved around, I have run the `move-pages.py` script to move the pages and update the image paths on the chinese repo
    - [ ] After the script has been run, I have created an additional PR in `moonbeam-docs-cn`
- [ ] If images have been added, I have run the `compress-images.py` script to compress the images.
- [ ] If variables (in variables.yml) need to be updated (such as a name change), I have updated the `moonbeam-docs-cn` repo to use the new variables
- [ ] If this page requires a disclaimer, I have added one

### Corresponding PRs

Please link to any corresponding PRs here.

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [ ] No additional PRs are required after the translations are done

#### Items to be Updated

Please list any of the items that will need to be added or deleted after the translations are done here.
