### PR TITLE
update binary instructions

### DIFF
--- a/builders/get-started/networks/moonbeam-dev.md
+++ b/builders/get-started/networks/moonbeam-dev.md
@@ -102,6 +102,13 @@ Next, update your PATH environment variable by running:
 
 Now, build the development node by running:
 
+!!! note
+    If you are using Ubuntu 20.04 or 22.04, then you will need to install these additional dependencies before building the binary:
+
+    ```
+    apt install clang protobuf-compiler libprotobuf-dev -y 
+    ```
+
 ```
 --8<-- 'code/setting-up-node/build.md'
 ```

--- a/node-operators/networks/run-a-node/systemd.md
+++ b/node-operators/networks/run-a-node/systemd.md
@@ -94,7 +94,7 @@ The following commands will build the latest release of the Moonbeam parachain.
 5. Build the parachain binary:
 
     !!! note
-        If you are using Ubuntu 22.04, then you will need to install these additional dependencies before building the binary:
+        If you are using Ubuntu 20.04 or 22.04, then you will need to install these additional dependencies before building the binary:
 
         ```
         apt install clang protobuf-compiler libprotobuf-dev -y 


### PR DESCRIPTION
### Description

Update the instructions for building the binary. If on Ubuntu 20.04 or 22.04, additional dependencies will need to be installed.

### Checklist

- [ ] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [ ] Will need to create PR in `moonbeam-docs` repo to remove images
- [ ] Will need to create PR in `moonbeam-docs` repo to remove variables
- [ ] Will need to create PR in `moonbeam-mkdocs` repo to add redirects for Chinese site
- [x] No additional PRs are required after the translations are done
