### PR TITLE
bump moonriver to v0.30.0

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -48,7 +48,7 @@ purestake/moonbeam:v0.29.0 \
 ```
 docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.29.0 \
+purestake/moonbeam:v0.30.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \
@@ -66,7 +66,7 @@ purestake/moonbeam:v0.29.0 \
 ```
 docker run -p 9944:9944 -v "/var/lib/moonriver-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.29.0 \
+purestake/moonbeam:v0.30.0 \
 --base-path=/data \
 --chain moonriver \
 --name="YOUR-NODE-NAME" \

--- a/variables.yml
+++ b/variables.yml
@@ -410,9 +410,9 @@ networks:
     chain_id: 1285
     hex_chain_id: '0x505'
     node_directory: /var/lib/moonriver-data
-    parachain_release_tag: v0.29.0
-    parachain_sha256sum: afc7f4cf869fea6af3e4d104b5e99b764df6baca8b6157cc4e1fd8a345e75623
-    tracing_tag: purestake/moonbeam-tracing:v0.29.0-2100-latest
+    parachain_release_tag: v0.30.0
+    parachain_sha256sum: b0ee08ab990c38c1aba1b0c9f141bfc9488f1af9a3ef2996af3ca79cbf32dbd9
+    tracing_tag: purestake/moonbeam-tracing:v0.30.0-2201-latest
     chain_spec: moonriver
     block_explorer: https://moonriver.moonscan.io/
     binary_name: moonbeam


### PR DESCRIPTION
### Description

Bump Moonriver to client v0.30.0
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/246
