### PR TITLE
bump moonbeam to v0.30.3

### DIFF
--- a/.snippets/text/full-node/macos-node.md
+++ b/.snippets/text/full-node/macos-node.md
@@ -13,7 +13,7 @@ For client versions prior to v0.30.0, `--rpc-port` was used to specify the port 
 ```
 docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.30.0 \
+purestake/moonbeam:v0.30.3 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \
@@ -31,7 +31,7 @@ purestake/moonbeam:v0.30.0 \
 ```
 docker run -p 9944:9944 -v "/var/lib/moonbeam-data:/data" \
 -u $(id -u ${USER}):$(id -g ${USER}) \
-purestake/moonbeam:v0.30.0 \
+purestake/moonbeam:v0.30.3 \
 --base-path=/data \
 --chain moonbeam \
 --name="YOUR-NODE-NAME" \

--- a/variables.yml
+++ b/variables.yml
@@ -756,9 +756,9 @@ networks:
     chain_id: 1284
     hex_chain_id: '0x504'
     node_directory: /var/lib/moonbeam-data
-    parachain_release_tag: v0.30.0
-    parachain_sha256sum: b0ee08ab990c38c1aba1b0c9f141bfc9488f1af9a3ef2996af3ca79cbf32dbd9
-    tracing_tag: purestake/moonbeam-tracing:v0.30.0-2201-latest
+    parachain_release_tag: v0.30.3
+    parachain_sha256sum: 5957fa67e87ae536c724b27c95cc5ee5844d2bb97ac1a79d66e642e7031c2fd1
+    tracing_tag: purestake/moonbeam-tracing:v0.30.3-2201-latest
     chain_spec: moonbeam
     block_explorer: https://moonscan.io
     binary_name: moonbeam


### PR DESCRIPTION
### Description

bump moonbeam to v0.30.3
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/264
