### PR TITLE
minor updates to the send and execute xcm messages page

### DIFF
--- a/.snippets/code/polkadotXcm/xcmExecute/encodedCalldata.js
+++ b/.snippets/code/polkadotXcm/xcmExecute/encodedCalldata.js
@@ -38,10 +38,10 @@ const generateCallData = async () => {
   const api = await ApiPromise.create({ provider: substrateProvider });
 
   // 6. Create the extrinsic
-  let tx = api.tx.polkadotXcm.execute(xcmMessage, maxWeight);
+  const tx = api.tx.polkadotXcm.execute(xcmMessage, maxWeight);
 
   // 7. Get SCALE Encoded Calldata
-  let encodedCall = tx.method.toHex();
+  const encodedCall = tx.method.toHex();
   console.log(`Encoded Calldata: ${encodedCall}`);
 };
 

--- a/.snippets/code/polkadotXcm/xcmSend/encodedCalldata.js
+++ b/.snippets/code/polkadotXcm/xcmSend/encodedCalldata.js
@@ -34,7 +34,7 @@ const instr3 = {
     assets: { Wild: 'All' },
     max_assets: 1,
     beneficiary: {
-      parents: 0,
+      parents: 1,
       interior: { X1: { AccountId32: { network: 'Any', id: bob } } },
     },
   },
@@ -49,10 +49,10 @@ const generateCallData = async () => {
   const api = await ApiPromise.create({ provider: substrateProvider });
 
   // 7. Create the extrinsic
-  let tx = api.tx.polkadotXcm.execute(xcmMessage, '0');
+  const tx = api.tx.polkadotXcm.execute(xcmMessage, '0');
 
   // 8. Get SCALE Encoded Calldata
-  let encodedCall = tx.method.toHex();
+  const encodedCall = tx.method.toHex();
   console.log(`Encoded Calldata: ${encodedCall}`);
 };
 

--- a/.snippets/code/polkadotXcm/xcmSend/ethers.js
+++ b/.snippets/code/polkadotXcm/xcmSend/ethers.js
@@ -16,7 +16,7 @@ const xcmUtils = new ethers.Contract(
 const sendXcm = async () => {
   // Define parameters required for the xcmSend function
   const encodedCalldata =
-    '0x020c0004000100000f0000c16ff2862313000100000f0000c16ff28623000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67';
+    '0x020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67';
   const dest = [
     1, // Parents: 1 
     [] // Interior: Here

--- a/.snippets/code/polkadotXcm/xcmSend/web3.js
+++ b/.snippets/code/polkadotXcm/xcmSend/web3.js
@@ -14,7 +14,7 @@ const xcmUtils = new web3.eth.Contract(
 const sendXcm = async () => {
   // Define parameters required for the xcmSend function
   const encodedCalldata =
-    '0x020c0004000100000f0000c16ff2862313000100000f0000c16ff28623000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67';
+    '0x020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67';
   const dest = [
     1, // Parents: 1 
     [] // Interior: Here

--- a/.snippets/code/polkadotXcm/xcmSend/web3.py
+++ b/.snippets/code/polkadotXcm/xcmSend/web3.py
@@ -1,28 +1,28 @@
 from web3 import Web3
 
 abi = 'XCM-UTILS-ABI-HERE' # Paste or import the x-tokens ABI
-privateKey = 'INSERT-YOUR-PRIVATE-KEY' # This is for demo purposes, never store your private key in plain text
+private_key = 'INSERT-YOUR-PRIVATE-KEY' # This is for demo purposes, never store your private key in plain text
 address = 'INSERT-YOUR-ADDRESS' # The wallet address that corresponds to your private key
 
 # Create Web3 wallet & contract instance
 web3 = Web3(Web3.HTTPProvider('https://rpc.api.moonbase.moonbeam.network'))
-xcmUtils = web3.eth.contract(
+xcm_utils = web3.eth.contract(
     address='0x000000000000000000000000000000000000080C', # XCM Utilities Precompile address
     abi=abi
 )
 
 def sendXcm():
     # Define parameters required for the xcmSend function
-    encodedCalldata = '0x020c0004000100000f0000c16ff2862313000100000f0000c16ff28623000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67'
+    encoded_calldata = '0x020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67'
     dest = [
         1, # Parents: 1 
         [] # Interior: Here
     ]
 
     # Create transaction
-    tx = xcmUtils.functions.xcmSend(
+    tx = xcm_utils.functions.xcmSend(
         dest,
-        encodedCalldata
+        encoded_calldata
     ).buildTransaction(
         {
             'from': address,
@@ -31,10 +31,10 @@ def sendXcm():
     )
 
     # Sign transaction
-    signedTx = web3.eth.account.sign_transaction(tx, privateKey)
+    signed_tx = web3.eth.account.sign_transaction(tx, private_key)
 
     # Send tx
-    hash = web3.eth.send_raw_transaction(signedTx.rawTransaction)
+    hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
     receipt = web3.eth.wait_for_transaction_receipt(hash)
     print(f'Transaction receipt: { receipt.transactionHash.hex() }')
 

--- a/builders/interoperability/xcm/send-execute-xcm.md
+++ b/builders/interoperability/xcm/send-execute-xcm.md
@@ -318,7 +318,7 @@ To summarize, the steps you're taking are as follows:
 You can use `node` to run the script and the result will be logged to the console. The result should be slightly different than the encoded calldata from the previous step: 
 
 ```
-0x1c03020c0004000100000f0000c16ff2862313000100000f0000c16ff28623000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d670000000000000000
+0x1c03020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d670000000000000000
 ```
 
 Before you can use the encoded calldata, you'll need to remove some of the hexadecimal characters that do not correspond to the XCM message, such as the call index for the `polkadotXcm.execute` function, which will be the first 4 characters, and the maximum weight, which will be the last 16 characters:
@@ -332,7 +332,7 @@ max weight:  0000000000000000
 So, for this example, the encoded calldata for the XCM message alone is: 
 
 ```
-0x020c0004000100000f0000c16ff2862313000100000f0000c16ff28623000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67
+0x020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67
 ```
 
 Now that you have the multilocation of the destination and the SCALE encoded XCM message, you can use the following code snippets to programmatically call the `xcmSend` function of the XCM Utilities Precompile using your Ethereum library of choice:


### PR DESCRIPTION
### Description

Was using the wrong calldata so this PR fixes that and applies some other minor fixes such as using `const` instead of `let` and using snake case instead of camel in python snippets

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira
