### PR TITLE
format python files and update maxWeight to be a number (not string)

### DIFF
--- a/.snippets/code/polkadotXcm/xcmExecute/web3.py
+++ b/.snippets/code/polkadotXcm/xcmExecute/web3.py
@@ -1,20 +1,24 @@
 from web3 import Web3
 
-abi = 'XCM-UTILS-ABI-HERE' # Paste or import the x-tokens ABI
-privateKey = 'INSERT-YOUR-PRIVATE-KEY' # This is for demo purposes, never store your private key in plain text
-address = 'INSERT-YOUR-ADDRESS' # The wallet address that corresponds to your private key
+abi = 'XCM-UTILS-ABI-HERE'  # Paste or import the x-tokens ABI
+# This is for demo purposes, never store your private key in plain text
+privateKey = 'INSERT-YOUR-PRIVATE-KEY'
+# The wallet address that corresponds to your private key
+address = 'INSERT-YOUR-ADDRESS'
 
 # Create Web3 wallet & contract instance
 web3 = Web3(Web3.HTTPProvider('https://rpc.api.moonbase.moonbeam.network'))
 xcmUtils = web3.eth.contract(
-    address='0x000000000000000000000000000000000000080C', # XCM Utilities Precompile address
+    # XCM Utilities Precompile address
+    address='0x000000000000000000000000000000000000080C',
     abi=abi
 )
+
 
 def executeXcmMessageLocally():
     # Define parameters required for the xcmExecute function
     encodedCalldata = '0x020800040000010403001300008a5d784563010d010004000103003cd0a705a2dc65e5b1e1205896baa2be8a07c6e0'
-    maxWeight = '1000000000'
+    maxWeight = 1000000000
 
     # Create transaction
     tx = xcmUtils.functions.xcmExecute(
@@ -34,5 +38,6 @@ def executeXcmMessageLocally():
     hash = web3.eth.send_raw_transaction(signedTx.rawTransaction)
     receipt = web3.eth.wait_for_transaction_receipt(hash)
     print(f'Transaction receipt: { receipt.transactionHash.hex() }')
+
 
 executeXcmMessageLocally()

--- a/.snippets/code/polkadotXcm/xcmSend/web3.py
+++ b/.snippets/code/polkadotXcm/xcmSend/web3.py
@@ -1,22 +1,26 @@
 from web3 import Web3
 
-abi = 'XCM-UTILS-ABI-HERE' # Paste or import the x-tokens ABI
-private_key = 'INSERT-YOUR-PRIVATE-KEY' # This is for demo purposes, never store your private key in plain text
-address = 'INSERT-YOUR-ADDRESS' # The wallet address that corresponds to your private key
+abi = 'XCM-UTILS-ABI-HERE'  # Paste or import the x-tokens ABI
+# This is for demo purposes, never store your private key in plain text
+private_key = 'INSERT-YOUR-PRIVATE-KEY'
+# The wallet address that corresponds to your private key
+address = 'INSERT-YOUR-ADDRESS'
 
 # Create Web3 wallet & contract instance
 web3 = Web3(Web3.HTTPProvider('https://rpc.api.moonbase.moonbeam.network'))
 xcm_utils = web3.eth.contract(
-    address='0x000000000000000000000000000000000000080C', # XCM Utilities Precompile address
+    # XCM Utilities Precompile address
+    address='0x000000000000000000000000000000000000080C',
     abi=abi
 )
+
 
 def sendXcm():
     # Define parameters required for the xcmSend function
     encoded_calldata = '0x020c000400010000070010a5d4e81300010000070010a5d4e8000d010004010101000c36e9ba26fa63c60ec728fe75fe57b86a450d94e7fee7f9f9eddd0d3f400d67'
     dest = [
-        1, # Parents: 1 
-        [] # Interior: Here
+        1,  # Parents: 1
+        []  # Interior: Here
     ]
 
     # Create transaction
@@ -37,5 +41,6 @@ def sendXcm():
     hash = web3.eth.send_raw_transaction(signed_tx.rawTransaction)
     receipt = web3.eth.wait_for_transaction_receipt(hash)
     print(f'Transaction receipt: { receipt.transactionHash.hex() }')
+
 
 sendXcm()


### PR DESCRIPTION
### Description

This PR formats the python files for sending and executing XCM messages and updates `maxWeight` to be a number (not string)

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
