### PR TITLE
update referenda docs for changes made in RT2300

### DIFF
--- a/builders/build/historical-updates.md
+++ b/builders/build/historical-updates.md
@@ -495,6 +495,24 @@ For more information, you can review the [relative PR on GitHub](https://github.
 
 ***
 
+### Referenda Pallet {: #referenda-pallet }
+
+To support refunds for Submission Deposits on closed referendum, a migration was introduced that updated the `ReferendumInfo` type. The following invariants of `ReferendumInfo` were changed so that the second parameter, `Deposit<AccountId, Balance>`, is now optional, `Option<Deposit<AccountId, Balance>>`: `Approved`, `Rejected`, `Cancelled`, and `TimedOut`.
+
+This stemmed from an upstream change to the [Substrate](https://github.com/paritytech/substrate/pull/12788){target=_blank} repository.
+
+This migration was executed at the following runtimes and blocks:
+
+|    Network     | Executed Runtime | Block Applied |
+|:--------------:|:----------------:|:-------------:|
+|    Moonbeam    |      RT2302      |    3456477    |
+|   Moonriver    |      RT2302      |    4133065    |
+| Moonbase Alpha |      RT2301      |    4172407    |
+
+For more information, you can review the [relative PR on GitHub](https://github.com/PureStake/moonbeam/pull/2134){target=_blank}.
+
+***
+
 ### XCM-Related Pallets {: #xcm-related-pallets }
 
 #### Update Transact Info Storage Item {: #update-transaction-info }

--- a/builders/pallets-precompiles/pallets/referenda.md
+++ b/builders/pallets-precompiles/pallets/referenda.md
@@ -27,6 +27,7 @@ The Referenda Pallet provides the following extrinsics (functions):
 - **kill**(index) - cancels an ongoing referendum and slashes the deposits given the index of the referendum to cancel. This type of action requires a proposal to be created and assigned to the Emergency Killer Track
 - **placeDecisionDeposit**(index) - posts the Decision Deposit for a referendum given the index of the referendum
 - **refundDecisionDeposit**(index) - refunds the Decision Deposit for a closed referendum back to the depositor given the index of the referendum
+- **refundSubmissionDeposit**(index) - refunds the Submission Deposit for a closed referendum back to the depositor given the index of the referendum
 - **submit**(proposalOrigin, proposal, enactmentMoment) - proposes a referendum on a privileged action given the Origin from which the proposal should be executed, the proposal, and the moment tht the proposal should be enacted
 
 ### Storage Methods {: #storage-methods }


### PR DESCRIPTION
### Description

This PR adds the new `refundSubmissionDeposit` extrinsic and includes a new migration on the historical updates page, which made it possible for submission deposits to be refunded.

Original changes: https://github.com/PureStake/moonbeam/pull/2134

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done

