### PR TITLE
Update Conviction Voting Precompile page with RT2300 changes

### DIFF
--- a/builders/pallets-precompiles/pallets/conviction-voting.md
+++ b/builders/pallets-precompiles/pallets/conviction-voting.md
@@ -34,7 +34,7 @@ The Conviction Voting Pallet provides the following extrinsics (functions):
 
 - **undelegate**(class) - undelegates the voting power for a particular class (Origin) of polls (referenda). Tokens may be unlocked following once an amount of time consistent with the lock period of the conviction with which the delegation was issued. Emits an `Undelegated` event
 - **unlock**(class, target) - removes a lock for a prior vote/delegation vote within a particluar class (Origin), which has expired
-- **vote**(pollIndex, vote) - submits a vote in a poll (referendum). If the vote is "aye", the vote is to enact the proposal; otherwise, it is a "nay" vote to keep the status quo
+- **vote**(pollIndex, vote) - submits a vote in a poll (referendum). If the vote is "Aye", the vote is to enact the proposal; otherwise, it is a "Nay" vote to keep the status quo
 
 ### Storage Methods {: #storage-methods }
 

--- a/builders/pallets-precompiles/pallets/conviction-voting.md
+++ b/builders/pallets-precompiles/pallets/conviction-voting.md
@@ -34,13 +34,13 @@ The Conviction Voting Pallet provides the following extrinsics (functions):
 
 - **undelegate**(class) - undelegates the voting power for a particular class (Origin) of polls (referenda). Tokens may be unlocked following once an amount of time consistent with the lock period of the conviction with which the delegation was issued. Emits an `Undelegated` event
 - **unlock**(class, target) - removes a lock for a prior vote/delegation vote within a particluar class (Origin), which has expired
-- **vote**(pollIndex, vote) - submits a vote in a poll (referendum). If the vote is "aye", the vote is to enact the proposal; otherwise it is a "nay" vote to keep the status quo
+- **vote**(pollIndex, vote) - submits a vote in a poll (referendum). If the vote is "aye", the vote is to enact the proposal; otherwise, it is a "nay" vote to keep the status quo
 
 ### Storage Methods {: #storage-methods }
 
 The Conviction Voting Pallet includes the following read-only storage methods to obtain chain state data:
 
-- **classLocksFor**(AccountId20) - returns the voting classes (Origins) which have a non-zero lock requirement and the lock amounts which they require
+- **classLocksFor**(AccountId20) - returns the voting classes (Origins), which have a non-zero lock requirement and the lock amounts which they require
 - **palletVersion**() - returns the current pallet version
 - **votingFor**(AccountId20, u16) - returns all of the votes for a particular voter in a particular voting class (Origin)
 

--- a/builders/pallets-precompiles/precompiles/conviction-voting.md
+++ b/builders/pallets-precompiles/precompiles/conviction-voting.md
@@ -33,7 +33,7 @@ The Conviction Voting Precompile is located at the following address:
 
 [`ConvictionVoting.sol`](https://github.com/PureStake/moonbeam/blob/master/precompiles/conviction-voting/ConvictionVoting.sol){target=_blank} is a Solidity interface that allows developers to interact with the precompile's methods.
 
-The interfaces includes a `Conviction` enum that defines the Conviction multiplier types. The enum has the following variables:
+The interfaces includes a `Conviction` enum that defines the [Conviction multiplier](/learn/features/governance/#conviction-multiplier-v2){target=_blank} types. The enum has the following variables:
 
  - **None** -  0.1x votes, unlocked
  - **Locked1x** - 1x votes, locked for an Enactment Period following a successful vote
@@ -45,8 +45,12 @@ The interfaces includes a `Conviction` enum that defines the Conviction multipli
 
 The interface includes the following functions:
 
+- **votingFor**(*address* who, *uint16* trackId) - returns the votes for a given account and Track
+- **classLocksFor**(*address* who) - returns the class locks for a given account
 - **voteYes**(*uint32* pollIndex, *uint256* voteAmount, *Conviction* conviction) - votes a Conviction-weighted "Aye" on a poll (referendum)
 - **voteNo**(*uint32* pollIndex, *uint256* voteAmount, *Conviction* conviction) - votes a Conviction-weighted "Nay" on a poll (referendum)
+- **voteSplit**(*uint32* pollIndex, *uint256* aye, *uint256* nay) - votes a split vote, with a given amount locked for "Aye" and a given amount locked for "Nay", on a poll (referendum)
+- **voteSplitAbstain**(*uint32* pollIndex, *uint256* aye, *uint256* nay) - votes a split abstained vote, with a given amount locked for "Aye", a given amount locked for "Nay", and a given amount locked for an abstain vote (support), on a poll (referendum)
 - **removeVote**(*uint32* pollIndex) - [removes a vote](/builders/pallets-precompiles/pallets/conviction-voting/#extrinsics){target=_blank} in a poll (referendum)
 - **removeOtherVote**(*address* target, *uint16* trackId, *uint32* pollIndex) - [removes a vote](/builders/pallets-precompiles/pallets/conviction-voting/#extrinsics){target=_blank} in a poll (referendum) for another voter
 - **delegate**(*uint16* trackId, *address* representative, *Conviction* conviction, *uint256* amount) - delegates another account as a representative to place a Conviction-weighted vote on the behalf of the sending account for a specific Track
@@ -64,7 +68,10 @@ Each of these functions have the following parameters:
 The interface also includes the following events:
 
 - **Voted**(*uint32 indexed* pollIndex, *address* voter, *bool* aye, *uint256* voteAmount, *uint8* conviction) - emitted when an account makes a vote
-- **VoteRemoved**(*uint32 indexed* pollIndex, *address* voter) - emitted when an account's (`voter`) vote has been removed
+- **VoteSplit**(*uint32 indexed* pollIndex, *address* voter, *uin256* aye, *uint256* nay) - emitted when an account makes a split vote
+- **VoteSplitAbstained**(*uint32 indexed* pollIndex, *address* voter, *uin256* aye, *uint256* nay, *uint256* nay) - emitted when an account makes a split abstained vote
+- **VoteRemoved**(*uint32 indexed* pollIndex, *address* voter) - emitted when an account's (`voter`) vote has been removed from an ongoing poll (referendum)
+- **VoteRemovedForTrack**(*uint32 indexed* pollIndex, *uint16* trackId, *address* voter) - emitted when an account's (`voter`) vote has been removed from an ongoing poll (referendum) for a specific Track
 - **VoteRemovedOther**(*uint32 indexed* pollIndex, *address* caller, *address* target, *uint16* trackId) - emitted when an account (`caller`) removed a vote for another account (`target`)
 - **Delegated**(*uint16 indexed* trackId, *address* from, *address* to, *uint256* delegatedAmount, *uint8* conviction) - emitted when an account (`from`) delegates a Conviction-weighted vote of a given amount to another account (`to`)
 - **Undelegated**(*uint16 indexed* trackId, *address* caller) - emitted when an account's (`caller`) delegations are removed for a specific Track


### PR DESCRIPTION
### Description

This PR adds the new extrinsics and events introduced in RT 2300 around class locks, split votes, etc.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
