### PR TITLE
update snippets to use from_wei and to_wei

### DIFF
--- a/.snippets/code/web3py-tx/balances.py
+++ b/.snippets/code/web3py-tx/balances.py
@@ -13,8 +13,8 @@ address_from = 'ADDRESS_FROM_HERE'
 address_to = 'ADDRESS_TO_HERE'
 
 # 3. Fetch balance data
-balance_from = web3.fromWei(web3.eth.getBalance(address_from), 'ether')
-balance_to = web3.fromWei(web3.eth.getBalance(address_to), 'ether')
+balance_from = web3.from_wei(web3.eth.getBalance(address_from), 'ether')
+balance_to = web3.from_wei(web3.eth.getBalance(address_to), 'ether')
 
 print(f'The balance of { address_from } is: { balance_from } ETH')
 print(f'The balance of { address_to } is: { balance_to } ETH')

--- a/.snippets/code/web3py-tx/transaction.py
+++ b/.snippets/code/web3py-tx/transaction.py
@@ -30,7 +30,7 @@ tx_create = web3.eth.account.sign_transaction(
         'gasPrice': web3.eth.generate_gas_price(),
         'gas': 21000,
         'to': address_to,
-        'value': web3.toWei('1', 'ether'),
+        'value': web3.to_wei('1', 'ether'),
     },
     account_from['private_key'],
 )

--- a/builders/build/eth-api/libraries/web3py.md
+++ b/builders/build/eth-api/libraries/web3py.md
@@ -96,7 +96,7 @@ Next, you will create the script for this file and complete the following steps:
 
 1. [Set up the Web3 provider](#setup-web3-with-moonbeam)
 2. Define the `address_from` and `address_to` variables
-3. Get the balance for the accounts using the `web3.eth.get_balance` function and format the results using the `web3.fromWei`
+3. Get the balance for the accounts using the `web3.eth.get_balance` function and format the results using the `web3.from_wei`
 
 ```python
 --8<-- 'code/web3py-tx/balances.py'
@@ -124,7 +124,7 @@ Next, you will create the script for this file and complete the following steps:
 2. [Set up the Web3 provider](#setup-web3-with-moonbeam)
 3. Define the `account_from`, including the `private_key`, and the `address_to` variables. The private key is required to sign the transaction. **Note: This is for example purposes only. Never store your private keys in a Python file**
 4. Use the [Web3.py Gas Price API](https://web3py.readthedocs.io/en/stable/gas_price.html){target=_blank} to set a gas price strategy. For this example, you'll use the imported `rpc_gas_price_strategy`
-5. Create and sign the transaction using the `web3.eth.account.sign_transaction` function. Pass in the `nonce` `gas`, `gasPrice`, `to`, and `value` for the transaction along with the sender's `private_key`. To get the `nonce` you can use the `web3.eth.get_transaction_count` function and pass in the sender's address. To predetermine the `gasPrice` you'll use the `web3.eth.generate_gas_price` function. For the `value`, you can format the amount to send from an easily readable format to Wei using the `web3.toWei` function
+5. Create and sign the transaction using the `web3.eth.account.sign_transaction` function. Pass in the `nonce` `gas`, `gasPrice`, `to`, and `value` for the transaction along with the sender's `private_key`. To get the `nonce` you can use the `web3.eth.get_transaction_count` function and pass in the sender's address. To predetermine the `gasPrice` you'll use the `web3.eth.generate_gas_price` function. For the `value`, you can format the amount to send from an easily readable format to Wei using the `web3.to_wei` function
 6. Using the signed transaction, you can then send it using the `web3.eth.send_raw_transaction` function and wait for the transaction receipt by using the `web3.eth.wait_for_transaction_receipt` function
 
 ```python


### PR DESCRIPTION
### Description

Update web3py snippets to use `from_wei` instead of `fromWei` and `to_wei` instead of `toWei`. Web3py has been deprecating and removing their functions that use camelCase in favor of snake_case
Goes with CN PR: https://github.com/PureStake/moonbeam-docs-cn/pull/286
