### PR TITLE
Chopsticks Update for v0.6.4

### DIFF
--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -13,7 +13,7 @@ description: Learn the basics of how to use Chopsticks to replay blocks, dissect
 
 Overall, Chopsticks aims to simplify the process of building blockchain applications on Substrate and make it accessible to a wider range of developers.
 
-## Configuring Chopsticks {: #configuring-chopsticks }
+## Forking Moonbeam with Chopsticks {: #forking-moonbeam }
 
 To use Chopsticks, you can install it as a package with the [Node package manager](https://nodejs.org/en){target=_blank} or [Yarn](https://yarnpkg.com/){target=_blank}:  
 
@@ -21,13 +21,13 @@ To use Chopsticks, you can install it as a package with the [Node package manage
 npm i @acala-network/chopsticks@latest
 ```
 
-Once installed, you can run commands with the Node package executor:  
+Once installed, you can run commands with the Node package executor. For example, this runs Chopstick's base command:  
 
 ```
 npx @acala-network/chopsticks
 ```
 
-Chopsticks' source repository includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can download the configuration files from the [source repository's `configs` folder](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
+To run Chopsticks, you will need some sort of configuration, typically through a file. Chopsticks' source repository includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can download the configuration files from the [source repository's `configs` folder](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
 
 Moonbeam, Moonriver, and Moonbase Alpha all have default files available:  
 
@@ -126,29 +126,9 @@ These are the settings that can be included in the config file:
 |           `html`           |                           Include to generate storage diff preview between blocks.                           |
 |   `mock-signature-host`    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
-## Forking Moonbeam {: #forking-moonbeam }
+You can use the configuration file with the base command `npx @acala-network/chopsticks` to fork assets by providing it with the `--config` flag.  
 
-The simplest way to fork Moonbeam is through the previously introduced configuration files:  
-
-=== "Moonbeam"
-    ```
-    npx @acala-network/chopsticks \
-    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
-    ```
-
-=== "Moonriver"
-    ```
-    npx @acala-network/chopsticks \
-    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
-    ```
-
-=== "Moonbase Alpha"
-    ```
-    npx @acala-network/chopsticks \
-    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
-    ```
-
-When providing the `config` flag, you can use a raw GitHub URL to the default configuration files, a path to a local configuration file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
+You can use a raw GitHub URL of the default configuration files, a path to a local configuration file, or simply use the chain's name for the `--config` flag. For example, the following commands all use Moonbeam's configuration in the same way:  
 
 === "Chain Name"
     ```
@@ -167,25 +147,35 @@ When providing the `config` flag, you can use a raw GitHub URL to the default co
     ```
 
 !!! note
-    If using a file path, make sure you've downloaded the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.
+    If using a file path, make sure you've downloaded the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}, or have created your own.
 
-A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
+A configuration file is not necessary, however. All of the settings (except `genesis` and `timestamp`) can also be passed as flags to configure the environment completely in the command line. For example, the following command forks Moonbase Alpha at block 100.
 
-The `npx @acala-network/chopsticks` command forks a chain, and includes the following flags, which are similar to the settings available in the configuration file:  
+```
+npx @acala-network/chopsticks --endpoint {{ networks.moonbase.rpc_url }} --block 100
+```
 
-|            Flag            |                                                 Description                                                  |
-|:--------------------------:|:------------------------------------------------------------------------------------------------------------:|
-|         `endpoint`         |                                    The endpoint of the parachain to fork.                                    |
-|          `block`           |                       Use to specify at which block hash or number to replay the fork.                       |
-|      `wasm-override`       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
-|            `db`            |               Path to the name of the file that stores or will store the parachain's database.               |
-|          `config`          |                                       Path or URL of the config file.                                        |
-|           `port`           |                                      The port to expose an endpoint on.                                      |
-|     `build-block-mode`     |                       How blocks should be built in the fork: batch, manual, instant.                        |
-|      `import-storage`      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
-| `allow-unresolved-imports` |              Whether to allow WASM unresolved imports when using a WASM to build the parachain.              |
-|           `html`           |                           Include to generate storage diff preview between blocks.                           |
-|   `mock-signature-host`    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
+### Quickstart {: #quickstart }
+
+The simplest way to fork Moonbeam is through the configuration files that are stored in the chopsticks GitHub repository:  
+
+=== "Moonbeam"
+    ```
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
+    ```
+
+=== "Moonriver"
+    ```
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
+    ```
+
+=== "Moonbase Alpha"
+    ```
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
+    ```
 
 ### Interacting with a Fork {: #interacting-with-a-fork }
 

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -38,7 +38,7 @@ yarn && \
 yarn build-wasm
 ```
 
-Chopsticks includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. If you installed from GitHub, you can view each of the default configuration files within the `configs` folder. If you installed with a package manager, you can download the configuration files from the [source repository](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
+Chopsticks includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. If you installed from GitHub, you can view each of the default configuration files within the `configs` folder. If you installed with a package manager, you can download the configuration files from the [source repository](https://github.com/AcalaNetwork/chopsticks.git){target=_blank} or use their raw URL.  
 
 Moonbeam, Moonriver, and Moonbase Alpha all have default files available. The example configuration below is the current configuration for Moonbeam:  
 
@@ -155,7 +155,7 @@ npx @acala-network/chopsticks run-block --endpoint wss://wss.api.moonbeam.networ
 To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [config folder from the GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
 
 ```
-npx @acala-network/chopsticks xcm --relaychain=configs/kusama.yml --parachain=configs/moonriver.yml --parachain=configs/karura.yml
+npx @acala-network/chopsticks xcm --r=configs/kusama.yml --p=configs/moonriver.yml --p=configs/karura.yml
 ```
 
 You should see something like the following output:  
@@ -169,7 +169,7 @@ You should see something like the following output:
 [12:49:08.227] INFO (xcm/21840): Connected relaychain 'Kusama' with parachain 'Karura'
 ```
 
-Including the `relaychain` command is optional, as Chopsticks will automatically mock a relay chain between networks.  
+Including the `r` flag as the relay chain is optional, as Chopsticks will automatically mock a relay chain between networks.  
 
 ## WebSocket Commands {: #websocket-commands }
 
@@ -195,7 +195,7 @@ Each method can be invoked by connecting to the websocket (`ws://localhost:8000`
 
 Parameters can be described in the following ways:  
 
-- **`options` { "to": number, "count": number }** - optional, leave `null` to create one block. A JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one parameter at a time within the JSON object if not `null`    
+- **`options` { "to": number, "count": number }** - a JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one parameter at a time within the JSON object if not `null`    
 - **`values` Object** - a JSON object resembling the path to a storage value, similar to what you would retrieve via Polkadot.js  
 - **`blockHash` string** - optional, the blockhash at which the storage value is changed
 - **`date` string** - a Date string (compatible with the JavaScript Date library) that will change the time stamp from which the next blocks being created will be at. All future blocks will be sequentially after that point in time

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -13,32 +13,21 @@ description: Learn the basics of how to use Chopsticks to replay blocks, dissect
 
 Overall, Chopsticks aims to simplify the process of building blockchain applications on Substrate and make it accessible to a wider range of developers.
 
-## Checking Prerequisites {: #checking-prerequisites }
+## Configuring Chopsticks {: #configuring-chopsticks }
 
-To use Chopsticks, you will need the following:  
-
-- Have [Node](https://nodejs.org/en/download/){target=_blank} installed  
-- Have [Docker](https://docs.docker.com/get-docker/){target=_blank} installed
-- (Optional) Have a recent version of [Rust installed](https://www.rust-lang.org/tools/install){target=_blank} 
-
-## Configuring Chopsticks {: configuring-chopsticks }
-
-There are two ways to use Chopsticks. The first and recommended way is by installing it as a package:  
+To use Chopsticks, you can install it as a package with the [Node package manager](https://nodejs.org/en){target=_blank} or [Yarn](https://yarnpkg.com/){target=_blank}:  
 
 ```
-yarn add @acala-network/chopsticks
+npm i @acala-network/chopsticks@latest
 ```
 
-The alternate option is to clone Chopsticks from its GitHub repository, add dependencies, and build it. Note that the commands in this guide will assume that you are using the package installation, which uses `npx @acala-network/chopsticks` or `yarn dlx` instead of `npm run` or `yarn start` for local builds:  
+Once installed, you can run commands with the Node package executor:  
 
 ```
-git clone --recurse-submodules https://github.com/AcalaNetwork/chopsticks.git && \
-cd chopsticks && \
-yarn && \
-yarn build-wasm
+npx @acala-network/chopsticks
 ```
 
-Chopsticks includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. If you installed from GitHub, you can view each of the default configuration files within the `configs` folder. If you installed with a package manager, you can download the configuration files from the [source repository](https://github.com/AcalaNetwork/chopsticks.git){target=_blank} or use their raw URL.  
+Chopsticks' source repository includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can download the configuration files from the [source repository's `configs` folder](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
 
 Moonbeam, Moonriver, and Moonbase Alpha all have default files available. The example configuration below is the current configuration for Moonbeam:  
 
@@ -92,6 +81,14 @@ The simplest way to fork Moonbeam is through the previously introduced configura
     npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
     ```
 
+When providing the config flag, you can use their raw URL, a path to the file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
+
+|  Method   |                                             Command                                             |
+|:------------:|:-----------------------------------------------------------------------------------------------:|
+|    Name   |        `npx @acala-network/chopsticks --config=moonbeam`                        |
+|    URL    | `npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml`                  |
+| File Path | Requires a local download of the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.<br>`npx @acala-network/chopsticks --config=configs/moonbeam.yml`                   |
+
 A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
 
 The `npx @acala-network/chopsticks` command forks a chain, and includes following flags:  
@@ -114,7 +111,7 @@ The `npx @acala-network/chopsticks` command forks a chain, and includes followin
 
 When running a fork, by default it will be accessible at `ws://localhost:8000`. You will be able to interact with the parachain via libraries such as [Polkadot.js](https://github.com/polkadot-js/common){target=_blank} and its [user interface, Polkadot.js Apps](https://github.com/polkadot-js/apps){target=_blank}.  
 
-You can interact with Chopsticks via the [Polkadot.js Apps hosted user interface](https://polkadot.js.org/apps/#/explorer){target=_blank}. To do so, visit the page and take the following steps:
+You can interact with Chopsticks via the [Polkadot.js Apps hosted user interface](https://polkadot.js.org/apps/#/explorer){target=_blank}. To do so, visit the page and take the following steps:  
 
 1. Click the icon in the top left
 2. Go to the bottom and open **Development**
@@ -155,18 +152,21 @@ npx @acala-network/chopsticks run-block --endpoint wss://wss.api.moonbeam.networ
 To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [config folder from the GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
 
 ```
-npx @acala-network/chopsticks xcm --r=configs/kusama.yml --p=configs/moonriver.yml --p=configs/karura.yml
+npx @acala-network/chopsticks xcm --r=kusama.yml --p=moonriver.yml --p=karura.yml
 ```
 
 You should see something like the following output:  
 
 ```
-[12:48:58.766] INFO (rpc/21840): Moonriver RPC listening on port 8000
-[12:49:03.266] INFO (rpc/21840): Karura RPC listening on port 8001
-[12:49:03.565] INFO (xcm/21840): Connected parachains [2000,2023]
-[12:49:07.058] INFO (rpc/21840): Kusama RPC listening on port 8002
-[12:49:07.557] INFO (xcm/21840): Connected relaychain 'Kusama' with parachain 'Moonriver'
-[12:49:08.227] INFO (xcm/21840): Connected relaychain 'Kusama' with parachain 'Karura'
+[13:50:57.807] INFO (rpc/64805): Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
+[13:50:59.655] INFO (rpc/64805): Moonriver RPC listening on port 8000
+[13:50:59.656] INFO (rpc/64805): Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/karura.yml
+[13:51:03.275] INFO (rpc/64805): Karura RPC listening on port 8001
+[13:51:03.586] INFO (xcm/64805): Connected parachains [2000,2023]
+[13:51:03.586] INFO (rpc/64805): Loading config file https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/kusama.yml
+[13:51:07.241] INFO (rpc/64805): Kusama RPC listening on port 8002
+[13:51:07.700] INFO (xcm/64805): Connected relaychain 'Kusama' with parachain 'Moonriver'
+[13:51:08.386] INFO (xcm/64805): Connected relaychain 'Kusama' with parachain 'Karura'
 ```
 
 Including the `r` flag as the relay chain is optional, as Chopsticks will automatically mock a relay chain between networks.  
@@ -193,12 +193,20 @@ Each method can be invoked by connecting to the websocket (`ws://localhost:8000`
 }
 ```
 
-Parameters can be described in the following ways:  
+The parameters above are formatted in the following ways:  
 
-- **`options` { "to": number, "count": number }** - a JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one parameter at a time within the JSON object if not `null`    
+|    Parameter   |                Format               |                                 Example                                |
+|:--------------:|:-----------------------------------:|:----------------------------------------------------------------------:|
+|    `options`   | `{ "to": number, "count": number }` |                             `{ "count": 5 }`                           |
+|    `values`    |               `Object`              |  `{ "Sudo": { "Key": "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b" } }` |
+|   `blockHash`  |               `string`              | `"0x1a34506b33e918a0106b100db027425a83681e2332fe311ee99d6156d2a91697"` |
+|     `date`     |                `Date`               |                          `"2030-08-15T00:00:00"`                       |
+| `hashOrNumber` |          `number | string`          |                                  `1000`                                |
+
+- **`options` { "to": number, "count": number }** - a JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one entry at a time within the JSON object  
 - **`values` Object** - a JSON object resembling the path to a storage value, similar to what you would retrieve via Polkadot.js  
-- **`blockHash` string** - optional, the blockhash at which the storage value is changed
-- **`date` string** - a Date string (compatible with the JavaScript Date library) that will change the time stamp from which the next blocks being created will be at. All future blocks will be sequentially after that point in time
-- **`hashOrNumber` number | string** - if found, the chain head will be set to the block with the block number or block hash of this value
+- **`blockHash` string** - optional, the blockhash at which the storage value is changed  
+- **`date` Date** - a Date string (compatible with the JavaScript Date library) that will change the time stamp from which the next blocks being created will be at. All future blocks will be sequentially after that point in time  
+- **`hashOrNumber` number | string** - if found, the chain head will be set to the block with the block number or block hash of this value  
 
 --8<-- 'text/disclaimers/third-party-content.md'

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -68,20 +68,23 @@ The simplest way to fork Moonbeam is through the previously introduced configura
 
 === "Moonbeam"
     ```
-    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
     ```
 
 === "Moonriver"
     ```
-    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
     ```
 
 === "Moonbase Alpha"
     ```
-    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
     ```
 
-When providing the config flag, you can use their raw URL, a path to the file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
+When providing the `config` flag, you can use raw GitHub URL to the default configuration files, a path to a local configuration file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
 
 |  Method   |                                             Command                                             |
 |:------------:|:-----------------------------------------------------------------------------------------------:|
@@ -91,7 +94,7 @@ When providing the config flag, you can use their raw URL, a path to the file, o
 
 A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
 
-The `npx @acala-network/chopsticks` command forks a chain, and includes following flags:  
+The `npx @acala-network/chopsticks` command forks a chain, and includes the following flags:  
 
 |           Flag           |                                             Description                                             |
 |:------------------------:|:---------------------------------------------------------------------------------------------------:|
@@ -152,7 +155,10 @@ npx @acala-network/chopsticks run-block --endpoint wss://wss.api.moonbeam.networ
 To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [config folder from the GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
 
 ```
-npx @acala-network/chopsticks xcm --r=kusama.yml --p=moonriver.yml --p=karura.yml
+npx @acala-network/chopsticks xcm \
+--r=kusama.yml \
+--p=moonriver.yml \
+--p=karura.yml
 ```
 
 You should see something like the following output:  

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -171,7 +171,7 @@ You should see something like the following output:
 
 Including the `relaychain` command is optional, as Chopsticks will automatically mock a relay chain between networks.  
 
-## WebSocket Commands
+## WebSocket Commands {: #websocket-commands }
 
 Chopsticks' internal websocket server has special endpoints that allows the manipulation of the local Substrate chain. These are the methods that can be invoked:  
 
@@ -195,7 +195,7 @@ Each method can be invoked by connecting to the websocket (`ws://localhost:8000`
 
 Parameters can be described in the following ways:  
 
-- **`options` { "to": number, "count": number }** - optional, leave `null` to create one block. Use `"to"` to create blocks up to a certain value, use `"count"` to increase by a certain number of blocks  
+- **`options` { "to": number, "count": number }** - optional, leave `null` to create one block. A JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one parameter at a time within the JSON object if not `null`    
 - **`values` Object** - a JSON object resembling the path to a storage value, similar to what you would retrieve via Polkadot.js  
 - **`blockHash` string** - optional, the blockhash at which the storage value is changed
 - **`date` string** - a Date string (compatible with the JavaScript Date library) that will change the time stamp from which the next blocks being created will be at. All future blocks will be sequentially after that point in time

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -38,7 +38,9 @@ yarn && \
 yarn build-wasm
 ```
 
-Chopsticks includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can view each of the default configuration files within the `configs` folder of the [source repository](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}. Moonbeam, Moonriver, and Moonbase Alpha all have default files available. The example configuration below is the current configuration for Moonbeam:  
+Chopsticks includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. If you installed from GitHub, you can view each of the default configuration files within the `configs` folder. If you installed with a package manager, you can download the configuration files from the [source repository](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
+
+Moonbeam, Moonriver, and Moonbase Alpha all have default files available. The example configuration below is the current configuration for Moonbeam:  
 
 ```yaml
 endpoint: wss://wss.api.moonbeam.network
@@ -64,7 +66,7 @@ import-storage:
     EligibleCount: 100
 ```
 
-The settings that can be included in the config file are the same as the flags in the [`dev` command](#forking-moonbeam){target=_blank}, as well as these additional options:  
+The settings that can be included in the config file are the same as the flags in the [base command](#forking-moonbeam){target=_blank}, as well as these additional options:  
 
 |  Option   |                                        Description                                         |
 |:---------:|:------------------------------------------------------------------------------------------:|
@@ -77,22 +79,22 @@ The simplest way to fork Moonbeam is through the previously introduced configura
 
 === "Moonbeam"
     ```
-    npx @acala-network/chopsticks dev --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
+    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
     ```
 
 === "Moonriver"
     ```
-    npx @acala-network/chopsticks dev --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
+    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonriver.yml
     ```
 
 === "Moonbase Alpha"
     ```
-    npx @acala-network/chopsticks dev --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
+    npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
     ```
 
 A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
 
-The `npx @acala-network/chopsticks dev` command forks a chain, and includes following flags:  
+The `npx @acala-network/chopsticks` command forks a chain, and includes following flags:  
 
 |           Flag           |                                             Description                                             |
 |:------------------------:|:---------------------------------------------------------------------------------------------------:|

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -110,21 +110,21 @@ Moonbeam, Moonriver, and Moonbase Alpha all have default files available:
 
 These are the settings that can be included in the config file:  
 
-|          Option          |                                                  Description                                                 |
-|:------------------------:|:------------------------------------------------------------------------------------------------------------:|
-|         genesis          |        The link to a parachain's raw genesis file to build the fork from, instead of an endpoint.            |
-|        timestamp         |                                     Timestamp of the block to fork from.                                     |
-|         endpoint         |                                   The endpoint of the parachain to fork.                                     |
-|          block           |                      Use to specify at which block hash or number to replay the fork.                        |
-|      wasm-override       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
-|            db            |               Path to the name of the file that stores or will store the parachain's database.               |
-|          config          |                                       Path or URL of the config file.                                        |
-|           port           |                                      The port to expose an endpoint on.                                      |
-|     build-block-mode     |                       How blocks should be built in the fork: batch, manual, instant.                        |
-|      import-storage      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
-| allow-unresolved-imports |             Whether to allow WASM unresolved imports when using a WASM to build the parachain.               |
-|           html           |                          Include to generate storage diff preview between blocks.                            |
-|   mock-signature-host    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
+|           Option           |                                                 Description                                                  |
+|:--------------------------:|:------------------------------------------------------------------------------------------------------------:|
+|         `genesis`          |          The link to a parachain's raw genesis file to build the fork from, instead of an endpoint.          |
+|        `timestamp`         |                                     Timestamp of the block to fork from.                                     |
+|         `endpoint`         |                                    The endpoint of the parachain to fork.                                    |
+|          `block`           |                       Use to specify at which block hash or number to replay the fork.                       |
+|      `wasm-override`       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
+|            `db`            |               Path to the name of the file that stores or will store the parachain's database.               |
+|          `config`          |                                       Path or URL of the config file.                                        |
+|           `port`           |                                      The port to expose an endpoint on.                                      |
+|     `build-block-mode`     |                       How blocks should be built in the fork: batch, manual, instant.                        |
+|      `import-storage`      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
+| `allow-unresolved-imports` |              Whether to allow WASM unresolved imports when using a WASM to build the parachain.              |
+|           `html`           |                           Include to generate storage diff preview between blocks.                           |
+|   `mock-signature-host`    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
 ## Forking Moonbeam {: #forking-moonbeam }
 
@@ -150,29 +150,42 @@ The simplest way to fork Moonbeam is through the previously introduced configura
 
 When providing the `config` flag, you can use a raw GitHub URL to the default configuration files, a path to a local configuration file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
 
-|  Method   |                                             Command                                             |
-|:------------:|:-----------------------------------------------------------------------------------------------:|
-|    Name   |        `npx @acala-network/chopsticks --config=moonbeam`                       |
-|    URL    | `npx @acala-network/chopsticks \<br>--config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml`                  |
-| File Path | Requires a local download of the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.<br>`npx @acala-network/chopsticks --config=configs/moonbeam.yml` |
+=== "Chain Name"
+    ```
+    npx @acala-network/chopsticks --config=moonbeam
+    ```
+
+=== "GitHub URL"
+    ```
+    npx @acala-network/chopsticks \
+    --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml
+    ```
+
+=== "Local File Path"
+    ```
+    npx @acala-network/chopsticks --config=configs/moonbeam.yml
+    ```
+
+!!! note
+    If using a file path, make sure you've downloaded the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.
 
 A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
 
 The `npx @acala-network/chopsticks` command forks a chain, and includes the following flags, which are similar to the settings available in the configuration file:  
 
-|           Flag           |                                                  Description                                                 |
-|:------------------------:|:------------------------------------------------------------------------------------------------------------:|
-|         endpoint         |                                   The endpoint of the parachain to fork.                                     |
-|          block           |                      Use to specify at which block hash or number to replay the fork.                        |
-|      wasm-override       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
-|            db            |               Path to the name of the file that stores or will store the parachain's database.               |
-|          config          |                                       Path or URL of the config file.                                        |
-|           port           |                                      The port to expose an endpoint on.                                      |
-|     build-block-mode     |                       How blocks should be built in the fork: batch, manual, instant.                        |
-|      import-storage      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
-| allow-unresolved-imports |             Whether to allow WASM unresolved imports when using a WASM to build the parachain.               |
-|           html           |                          Include to generate storage diff preview between blocks.                            |
-|   mock-signature-host    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
+|            Flag            |                                                 Description                                                  |
+|:--------------------------:|:------------------------------------------------------------------------------------------------------------:|
+|         `endpoint`         |                                    The endpoint of the parachain to fork.                                    |
+|          `block`           |                       Use to specify at which block hash or number to replay the fork.                       |
+|      `wasm-override`       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
+|            `db`            |               Path to the name of the file that stores or will store the parachain's database.               |
+|          `config`          |                                       Path or URL of the config file.                                        |
+|           `port`           |                                      The port to expose an endpoint on.                                      |
+|     `build-block-mode`     |                       How blocks should be built in the fork: batch, manual, instant.                        |
+|      `import-storage`      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
+| `allow-unresolved-imports` |              Whether to allow WASM unresolved imports when using a WASM to build the parachain.              |
+|           `html`           |                           Include to generate storage diff preview between blocks.                           |
+|   `mock-signature-host`    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
 ### Interacting with a Fork {: #interacting-with-a-fork }
 
@@ -203,16 +216,16 @@ You should now be able to interact with the fork as you would an active parachai
 
 In the case where you would like to replay a block and retrieve its information to dissect the effects of an extrinsic, you can use the `npx @acala-network/chopsticks run-block` command. Its following flags are:  
 
-|           Flag           |                                      Description                                       |
-|:------------------------:|:--------------------------------------------------------------------------------------:|
-|         endpoint         |                         The endpoint of the parachain to fork.                         |
-|          block           |            Use to specify at which block hash or number to replay the fork.            |
-|      wasm-override       |  Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.   |
-|            db            |    Path to the name of the file that stores or will store the parachain's database.    |
-|          config          |                            Path or URL of the config file.                             |
-| output-path=/[file_path] |   Use to print out results to a JSON file instead of printing it out in the console.   |
-|           html           | Include to generate an HTML representation of the storage diff preview between blocks. |
-|           open           |                        Whether to open the HTML representation.                        |
+|            Flag            |                                      Description                                       |
+|:--------------------------:|:--------------------------------------------------------------------------------------:|
+|         `endpoint`         |                         The endpoint of the parachain to fork.                         |
+|          `block`           |            Use to specify at which block hash or number to replay the fork.            |
+|      `wasm-override`       |  Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.   |
+|            `db`            |    Path to the name of the file that stores or will store the parachain's database.    |
+|          `config`          |                            Path or URL of the config file.                             |
+| `output-path=/[file_path]` |   Use to print out results to a JSON file instead of printing it out in the console.   |
+|           `html`           | Include to generate an HTML representation of the storage diff preview between blocks. |
+|           `open`           |                        Whether to open the HTML representation.                        |
 
 For example, running the following command will re-run Moonbeam's block 1000, and write the storage diff and other data in a `moonbeam-output.json` file:  
 
@@ -254,22 +267,22 @@ Including the `r` flag as the relay chain is optional, as Chopsticks will automa
 
 Chopsticks' internal websocket server has special endpoints that allows the manipulation of the local Substrate chain. These are the methods that can be invoked:  
 
-|     Method     |    Parameters     |                          Description                          |
-|:--------------:|:-----------------:|:-------------------------------------------------------------:|
-|  dev_newBlock  |      options      |               Generates one or more new blocks.               |
-| dev_setStorage | values, blockHash |         Create or overwrite the value of any storage.         |
-| dev_timeTravel |       date        |     Sets the timestamp of the block to the `date` value.      |
-|  dev_setHead   |   hashOrNumber    | Sets the head of the blockchain to a specific hash or number. |
+|      Method      |      Parameters       |                          Description                          |
+|:----------------:|:---------------------:|:-------------------------------------------------------------:|
+|  `dev_newBlock`  |       `options`       |               Generates one or more new blocks.               |
+| `dev_setStorage` | `values`, `blockHash` |         Create or overwrite the value of any storage.         |
+| `dev_timeTravel` |        `date`         |     Sets the timestamp of the block to the `date` value.      |
+|  `dev_setHead`   |    `hashOrNumber`     | Sets the head of the blockchain to a specific hash or number. |
 
 The parameters above are formatted in the following ways:  
 
-|    Parameter   |                Format               |                                 Example                                |
+|   Parameter    |               Format                |                                Example                                 |
 |:--------------:|:-----------------------------------:|:----------------------------------------------------------------------:|
-|    `options`   | `{ "to": number, "count": number }` |                             `{ "count": 5 }`                           |
-|    `values`    |               `Object`              |  `{ "Sudo": { "Key": "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b" } }` |
-|   `blockHash`  |               `string`              | `"0x1a34506b33e918a0106b100db027425a83681e2332fe311ee99d6156d2a91697"` |
-|     `date`     |                `Date`               |                          `"2030-08-15T00:00:00"`                       |
-| `hashOrNumber` |          `number | string`          |                                  `1000`                                |
+|   `options`    | `{ "to": number, "count": number }` |                            `{ "count": 5 }`                            |
+|    `values`    |              `Object`               | `{ "Sudo": { "Key": "0x6Be02d1d3665660d22FF9624b7BE0551ee1Ac91b" } }`  |
+|  `blockHash`   |              `string`               | `"0x1a34506b33e918a0106b100db027425a83681e2332fe311ee99d6156d2a91697"` |
+|     `date`     |               `Date`                |                        `"2030-08-15T00:00:00"`                         |
+| `hashOrNumber` |               `number               |                                string`                                 |
 
 - **`options` { "to": number, "count": number }** - a JSON object where `"to"` will create blocks up to a certain value, and `"count"` will increase by a certain number of blocks. Use only one entry at a time within the JSON object  
 - **`values` Object** - a JSON object resembling the path to a storage value, similar to what you would retrieve via Polkadot.js  

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -157,7 +157,7 @@ npx @acala-network/chopsticks --endpoint {{ networks.moonbase.rpc_url }} --block
 
 ### Quickstart {: #quickstart }
 
-The simplest way to fork Moonbeam is through the configuration files that are stored in the chopsticks GitHub repository:  
+The simplest way to fork Moonbeam is through the configuration files that are stored in the Chopsticks GitHub repository:  
 
 === "Moonbeam"
     ```

--- a/builders/build/substrate-api/chopsticks.md
+++ b/builders/build/substrate-api/chopsticks.md
@@ -29,38 +29,102 @@ npx @acala-network/chopsticks
 
 Chopsticks' source repository includes a set of [YAML](https://yaml.org/){target=_blank} configuration files that can be used to create a local copy of a variety of Substrate chains. You can download the configuration files from the [source repository's `configs` folder](https://github.com/AcalaNetwork/chopsticks.git){target=_blank}.  
 
-Moonbeam, Moonriver, and Moonbase Alpha all have default files available. The example configuration below is the current configuration for Moonbeam:  
+Moonbeam, Moonriver, and Moonbase Alpha all have default files available:  
 
-```yaml
-endpoint: wss://wss.api.moonbeam.network
-mock-signature-host: true
-db: ./db.sqlite
+=== "Moonbeam"
+    ```yaml
+    endpoint: wss://wss.api.moonbeam.network
+    mock-signature-host: true
+    db: ./db.sqlite
 
-import-storage:
-  System:
-    Account:
-      -
-        -
-          - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
-        - data:
-            free: "100000000000000000000000"
-  TechCommitteeCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  CouncilCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  TreasuryCouncilCollective:
-    Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
-  AuthorFilter:
-    EligibleRatio: 100
-    EligibleCount: 100
-```
+    import-storage:
+      System:
+        Account:
+          -
+            -
+              - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+            - data:
+                free: "100000000000000000000000"
+      TechCommitteeCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      CouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      TreasuryCouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      AuthorFilter:
+        EligibleRatio: 100
+        EligibleCount: 100
+    ```
 
-The settings that can be included in the config file are the same as the flags in the [base command](#forking-moonbeam){target=_blank}, as well as these additional options:  
+=== "Moonriver"
+    ```yaml
+    endpoint: wss://wss.moonriver.moonbeam.network
+    mock-signature-host: true
+    db: ./db.sqlite
 
-|  Option   |                                        Description                                         |
-|:---------:|:------------------------------------------------------------------------------------------:|
-|  genesis  | The link to a parachain's raw genesis file to build the fork from, instead of an endpoint. |
-| timestamp |                            Timestamp of the block to fork from.                            |
+    import-storage:
+      System:
+        Account:
+          -
+            -
+              - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+            - data:
+                free: "100000000000000000000000"
+      TechCommitteeCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      CouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      TreasuryCouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      AuthorFilter:
+        EligibleRatio: 100
+        EligibleCount: 100
+    ```
+
+=== "Moonbase Alpha"
+    ```yaml
+    endpoint: wss://wss.api.moonbase.moonbeam.network
+    mock-signature-host: true
+    db: ./db.sqlite
+
+    import-storage:
+      System:
+        Account:
+          -
+            -
+              - "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+            - data:
+                free: "100000000000000000000000"
+      TechCommitteeCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      CouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      TreasuryCouncilCollective:
+        Members: ["0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"]
+      Sudo:
+        Key: "0xf24FF3a9CF04c71Dbc94D0b566f7A27B94566cac"
+      AuthorFilter:
+        EligibleRatio: 100
+        EligibleCount: 100
+    ```
+
+These are the settings that can be included in the config file:  
+
+|          Option          |                                                  Description                                                 |
+|:------------------------:|:------------------------------------------------------------------------------------------------------------:|
+|         genesis          |        The link to a parachain's raw genesis file to build the fork from, instead of an endpoint.            |
+|        timestamp         |                                     Timestamp of the block to fork from.                                     |
+|         endpoint         |                                   The endpoint of the parachain to fork.                                     |
+|          block           |                      Use to specify at which block hash or number to replay the fork.                        |
+|      wasm-override       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
+|            db            |               Path to the name of the file that stores or will store the parachain's database.               |
+|          config          |                                       Path or URL of the config file.                                        |
+|           port           |                                      The port to expose an endpoint on.                                      |
+|     build-block-mode     |                       How blocks should be built in the fork: batch, manual, instant.                        |
+|      import-storage      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
+| allow-unresolved-imports |             Whether to allow WASM unresolved imports when using a WASM to build the parachain.               |
+|           html           |                          Include to generate storage diff preview between blocks.                            |
+|   mock-signature-host    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
 ## Forking Moonbeam {: #forking-moonbeam }
 
@@ -84,35 +148,41 @@ The simplest way to fork Moonbeam is through the previously introduced configura
     --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbase-alpha.yml
     ```
 
-When providing the `config` flag, you can use raw GitHub URL to the default configuration files, a path to a local configuration file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
+When providing the `config` flag, you can use a raw GitHub URL to the default configuration files, a path to a local configuration file, or simply use the chain's name. For example, the following commands all use Moonbeam's configuration in the same way:  
 
 |  Method   |                                             Command                                             |
 |:------------:|:-----------------------------------------------------------------------------------------------:|
-|    Name   |        `npx @acala-network/chopsticks --config=moonbeam`                        |
-|    URL    | `npx @acala-network/chopsticks --config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml`                  |
-| File Path | Requires a local download of the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.<br>`npx @acala-network/chopsticks --config=configs/moonbeam.yml`                   |
+|    Name   |        `npx @acala-network/chopsticks --config=moonbeam`                       |
+|    URL    | `npx @acala-network/chopsticks \<br>--config=https://raw.githubusercontent.com/AcalaNetwork/chopsticks/master/configs/moonbeam.yml`                  |
+| File Path | Requires a local download of the [Moonbeam configuration file](https://github.com/AcalaNetwork/chopsticks/blob/master/configs/moonbeam.yml){target=_blank}.<br>`npx @acala-network/chopsticks --config=configs/moonbeam.yml` |
 
 A configuration file is not necessary, however. There are additional commands and flags to configure the environment completely in the command line.  
 
-The `npx @acala-network/chopsticks` command forks a chain, and includes the following flags:  
+The `npx @acala-network/chopsticks` command forks a chain, and includes the following flags, which are similar to the settings available in the configuration file:  
 
-|           Flag           |                                             Description                                             |
-|:------------------------:|:---------------------------------------------------------------------------------------------------:|
-|         endpoint         |                               The endpoint of the parachain to fork.                                |
-|          block           |                  Use to specify at which block hash or number to replay the fork.                   |
-|      wasm-override       |         Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.         |
-|            db            |          Path to the name of the file that stores or will store the parachain's database.           |
-|          config          |                                   Path or URL of the config file.                                   |
-|           port           |                                 The port to expose an endpoint on.                                  |
-|     build-block-mode     |                   How blocks should be built in the fork: batch, manual, instant.                   |
-|      import-storage      |          A pre-defined JSON/YAML storage file path to override in the parachain's storage.          |
-| allow-unresolved-imports |         Whether to allow WASM unresolved imports when using a WASM to build the parachain.          |
-|           html           |                      Include to generate storage diff preview between blocks.                       |
-|   mock-signature-host    | Mock signature host so any signature starts with 0xdeadbeef and filled by 0xcd is considered valid. |
+|           Flag           |                                                  Description                                                 |
+|:------------------------:|:------------------------------------------------------------------------------------------------------------:|
+|         endpoint         |                                   The endpoint of the parachain to fork.                                     |
+|          block           |                      Use to specify at which block hash or number to replay the fork.                        |
+|      wasm-override       |             Path of the WASM to use as the parachain runtime, instead of an endpoint's runtime.              |
+|            db            |               Path to the name of the file that stores or will store the parachain's database.               |
+|          config          |                                       Path or URL of the config file.                                        |
+|           port           |                                      The port to expose an endpoint on.                                      |
+|     build-block-mode     |                       How blocks should be built in the fork: batch, manual, instant.                        |
+|      import-storage      |              A pre-defined JSON/YAML storage file path to override in the parachain's storage.               |
+| allow-unresolved-imports |             Whether to allow WASM unresolved imports when using a WASM to build the parachain.               |
+|           html           |                          Include to generate storage diff preview between blocks.                            |
+|   mock-signature-host    | Mock signature host so that any signature starts with `0xdeadbeef` and filled by `0xcd` is considered valid. |
 
 ### Interacting with a Fork {: #interacting-with-a-fork }
 
-When running a fork, by default it will be accessible at `ws://localhost:8000`. You will be able to interact with the parachain via libraries such as [Polkadot.js](https://github.com/polkadot-js/common){target=_blank} and its [user interface, Polkadot.js Apps](https://github.com/polkadot-js/apps){target=_blank}.  
+When running a fork, by default it will be accessible at: 
+
+```
+ws://localhost:8000
+```
+
+You will be able to interact with the parachain via libraries such as [Polkadot.js](https://github.com/polkadot-js/common){target=_blank} and its [user interface, Polkadot.js Apps](https://github.com/polkadot-js/apps){target=_blank}.  
 
 You can interact with Chopsticks via the [Polkadot.js Apps hosted user interface](https://polkadot.js.org/apps/#/explorer){target=_blank}. To do so, visit the page and take the following steps:  
 
@@ -147,12 +217,15 @@ In the case where you would like to replay a block and retrieve its information 
 For example, running the following command will re-run Moonbeam's block 1000, and write the storage diff and other data in a `moonbeam-output.json` file:  
 
 ```
-npx @acala-network/chopsticks run-block --endpoint wss://wss.api.moonbeam.network --block 1000 --output-path=./moonbeam-output.json
+npx @acala-network/chopsticks run-block  \
+--endpoint wss://wss.api.moonbeam.network  \
+--output-path=./moonbeam-output.json  \
+--block 1000
 ```
 
 ## XCM Testing {: #xcm-testing }
 
-To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [config folder from the GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
+To test out XCM messages between networks, you can fork multiple parachains and a relay chain locally. For example, the following will fork Moonriver, Karura, and Kusama given that you've downloaded the [`configs` directory from the source GitHub repository](https://github.com/AcalaNetwork/chopsticks/tree/master/configs){target=_blank}:  
 
 ```
 npx @acala-network/chopsticks xcm \
@@ -175,7 +248,7 @@ You should see something like the following output:
 [13:51:08.386] INFO (xcm/64805): Connected relaychain 'Kusama' with parachain 'Karura'
 ```
 
-Including the `r` flag as the relay chain is optional, as Chopsticks will automatically mock a relay chain between networks.  
+Including the `r` flag as the relay chain is optional, as Chopsticks will automatically mock a relay chain between networks. You can also use a raw GitHub URL or the name of a popular branch, similar to the base command.  
 
 ## WebSocket Commands {: #websocket-commands }
 
@@ -187,17 +260,6 @@ Chopsticks' internal websocket server has special endpoints that allows the mani
 | dev_setStorage | values, blockHash |         Create or overwrite the value of any storage.         |
 | dev_timeTravel |       date        |     Sets the timestamp of the block to the `date` value.      |
 |  dev_setHead   |   hashOrNumber    | Sets the head of the blockchain to a specific hash or number. |
-
-Each method can be invoked by connecting to the websocket (`ws://localhost:8000` by default) and sending the data and parameters in the following format. Replace `METHOD_NAME` with the name of the method, and replace or delete `PARAMETER_1` and `PARAMETER_2` with the parameter data relevant to the method:  
-
-```
-{
-    "jsonrpc": "2.0",
-    "id": 1,
-    "method": "METHOD_NAME",
-    "params": [PARAMETER_1, PARAMETER_2...]
-}
-```
 
 The parameters above are formatted in the following ways:  
 
@@ -214,5 +276,16 @@ The parameters above are formatted in the following ways:
 - **`blockHash` string** - optional, the blockhash at which the storage value is changed  
 - **`date` Date** - a Date string (compatible with the JavaScript Date library) that will change the time stamp from which the next blocks being created will be at. All future blocks will be sequentially after that point in time  
 - **`hashOrNumber` number | string** - if found, the chain head will be set to the block with the block number or block hash of this value  
+
+Each method can be invoked by connecting to the websocket (`ws://localhost:8000` by default) and sending the data and parameters in the following format. Replace `METHOD_NAME` with the name of the method, and replace or delete `PARAMETER_1` and `PARAMETER_2` with the parameter data relevant to the method:  
+
+```
+{
+    "jsonrpc": "2.0",
+    "id": 1,
+    "method": "METHOD_NAME",
+    "params": [PARAMETER_1, PARAMETER_2...]
+}
+```
 
 --8<-- 'text/disclaimers/third-party-content.md'


### PR DESCRIPTION
### Description

Chopsticks has had some recent updates, which means some of the commands don't work like they used to. `dry-run` still doesn't work with Moonbeam though.

I have also simplified & clarified sections of the docs.

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [X] No additional PRs are required after the translations are done
