### PR TITLE
Westend fixes for XCM

### DIFF
--- a/builders/interoperability/xcm/remote-evm-calls.md
+++ b/builders/interoperability/xcm/remote-evm-calls.md
@@ -134,7 +134,7 @@ When the XCM instruction gets executed in Moonbeam (Moonbase Alpha in this examp
     interior: {
       X1: {
         AccountId32: {
-          network: {westend: null },,
+          network: {westend: null },
           id: decodedAddress,
         },
       },

--- a/builders/interoperability/xcm/remote-evm-calls.md
+++ b/builders/interoperability/xcm/remote-evm-calls.md
@@ -110,7 +110,7 @@ For example, from the relay chain, the [`DescendOrigin`](https://github.com/pari
   DescendOrigin: {
     X1: {
       AccountId32: {
-        westend: null,
+        network: {westend: null },
         id: decodedAddress,
       },
     },
@@ -134,7 +134,7 @@ When the XCM instruction gets executed in Moonbeam (Moonbase Alpha in this examp
     interior: {
       X1: {
         AccountId32: {
-          westend: null,
+          network: {westend: null },,
           id: decodedAddress,
         },
       },

--- a/builders/interoperability/xcm/remote-evm-calls.md
+++ b/builders/interoperability/xcm/remote-evm-calls.md
@@ -110,7 +110,7 @@ For example, from the relay chain, the [`DescendOrigin`](https://github.com/pari
   DescendOrigin: {
     X1: {
       AccountId32: {
-        network: 'Westend',
+        westend: null,
         id: decodedAddress,
       },
     },
@@ -134,7 +134,7 @@ When the XCM instruction gets executed in Moonbeam (Moonbase Alpha in this examp
     interior: {
       X1: {
         AccountId32: {
-          network: 'Westend',
+          westend: null,
           id: decodedAddress,
         },
       },

--- a/builders/interoperability/xcm/remote-evm-calls.md
+++ b/builders/interoperability/xcm/remote-evm-calls.md
@@ -110,7 +110,7 @@ For example, from the relay chain, the [`DescendOrigin`](https://github.com/pari
   DescendOrigin: {
     X1: {
       AccountId32: {
-        network: {westend: null },
+        network: { westend: null },
         id: decodedAddress,
       },
     },
@@ -134,7 +134,7 @@ When the XCM instruction gets executed in Moonbeam (Moonbase Alpha in this examp
     interior: {
       X1: {
         AccountId32: {
-          network: {westend: null },
+          network: { westend: null },
           id: decodedAddress,
         },
       },

--- a/tutorials/interoperability/uniswapv2-swap-xcm.md
+++ b/tutorials/interoperability/uniswapv2-swap-xcm.md
@@ -51,7 +51,7 @@ The values are all summarized in the following table:
 |:-------------------------------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------:|
 |        Origin Chain Encoded Address         |                                                    `5EnnmEp2R92wZ7T8J2fKMxpc1nPW5uP8r5K3YUQGiFrw8uG6`                                                     |
 |        Origin Chain Decoded Address         |                                           `0x78914a4d7a946a0e4ed641f336b498736336e05096e342c799cc33c0f868d62f`                                            |
-| Origin Chain Account Name (Westend in hex)  |                                                                         `Westend`                                                                         |
+|          Origin Chain Account Name          |                                                                         `Westend`                                                                         |
 | Multilocation Received in Destination Chain | `{"parents":1,"interior":{"x1":{"accountId32":{"network": {"westend":null},"id":"0x78914a4d7a946a0e4ed641f336b498736336e05096e342c799cc33c0f868d62f"}}}}` |
 | Multilocation-Derivative Account (32 bytes) |                                           `0xda51eac6eb3502b0a113effcb3950c52e873a24c6ef54cab13abdd56a55ddd7e`                                            |
 | Multilocation-Derivative Account (20 bytes) |                                                       `0xda51eac6eb3502b0a113effcb3950c52e873a24c`                                                        |


### PR DESCRIPTION
### Description

We fixed this in some parts but not all. This ensure that we use the `DescendOrigin` now with how XCM V3 does it.

@eshaben could you please add this PR to the corresponding translation ticket :) 
