### PR TITLE
update session keys docs

### DIFF
--- a/builders/pallets-precompiles/precompiles/author-mapping.md
+++ b/builders/pallets-precompiles/precompiles/author-mapping.md
@@ -43,12 +43,6 @@ The precompile is located at the following address:
 - **addressOf**(*bytes32* nimbusId) - retrieves the address associated to a given Nimbus ID. If the Nimbus ID is unknown, it returns `0`
 - **keysOf**(*bytes32* nimbusId) - retrieves the keys associated to the given Nimbus ID. If the Nimbus ID is unknown, it returns empty bytes
 
-The following methods are **deprecated**, but will still exist for backwards compatibility:
-
- - **addAssociation**(*bytes32* nimbusId) — maps your author ID to the H160 account from which the transaction is being sent, ensuring it is the true owner of its private keys. It requires a [bond](#mapping-bonds). This method maintains backwards compatibility by setting the `keys` to the author ID by default
- - **updateAssociation**(*bytes32* oldNimbusId, *bytes32* newNimbusId) —  updates the mapping from an old author ID to a new one. Useful after a key rotation or migration. It executes both the `add` and `clear` association extrinsics automically, enabling key rotation without needing a second bond. This method maintains backwards compatibility by setting the `newKeys` to the author ID by default
- - **clearAssociation**(*bytes32* nimbusId) — clears the association of an author ID to the H160 account from which the transaction is being sent, which needs to be the owner of that author ID. Also refunds the bond
-
 ## Required Bonds {: #bonds }
 
 To follow along with this tutorial, you'll need to join the candidate pool and map your session keys to your H160 Ethereum-style account. Two bonds are required to perform both of these actions.
@@ -104,7 +98,7 @@ As previously mentioned, you can use a Ledger by connecting it to MetaMask, plea
 
 --8<-- 'text/collators/generate-session-keys.md'
 
-### Remix Set Up {: #remix-set-up } 
+### Remix Set Up {: #remix-set-up }
 
 To get started, get a copy of [`AuthorMappingInterface.sol`](https://github.com/PureStake/moonbeam/blob/master/precompiles/author-mapping/AuthorMappingInterface.sol){target=_blank} and take the following steps:
 

--- a/node-operators/networks/collators/account-management.md
+++ b/node-operators/networks/collators/account-management.md
@@ -7,7 +7,7 @@ description: Learn how to manage your collator account including generating sess
 
 ![Collator Account Management Banner](/images/node-operators/networks/collators/account-management/account-management-banner.png)
 
-## Introduction {: #introduction } 
+## Introduction {: #introduction }
 
 When running a collator node on Moonbeam-based networks, there are some account management activities that you will need to be aware of. First and foremost you will need to create [session keys](https://wiki.polkadot.network/docs/learn-keys#session-keys){target=_blank} for your primary and backup servers which will be used to determine block production and sign blocks.
 
@@ -15,13 +15,45 @@ In addition, there are some optional account management activities that you can 
 
 This guide will cover how to manage your collator account including generating and rotating your session keys, registering and updating your session keys, setting an identity, and creating proxy accounts.
 
-## Generate Session Keys {: #session-keys } 
+## Process to Add and Update Session Keys {: #process }
+
+The process for adding your session keys for the first time is the same as it would be for rotating your session keys. The process to create/rotate session keys is as follows:
+
+1. [Generate session keys](#session-keys) using the `author_rotateKeys` RPC method. The response to calling this method will be a 128 hexadecimal character string containing a Nimbus ID and the public key of a VRF session key
+2. [Join the candidate pool](/node-operators/networks/collators/activities/#become-a-candidate){target=_blank} if you haven't already
+3. [Map the session keys](#mapping-extrinsic) to your candidate account using the [Author Mapping Pallet](#author-mapping-interface)'s `setKeys(keys)` extrinsic, which accepts the entire 128 hexadecimal character string as the input. When you call `setKeys` for the first time, you'll be required to submit a [mapping bond](#mapping-bonds). If you're rotating your keys and you've previously submitted a mapping bond, no new bond is required
+
+Each step of the process is outlined in the following sections.
+
+## Generate Session Keys {: #session-keys }
 
 --8<-- 'text/collators/generate-session-keys.md'
 
-## Mapping Bonds {: #mapping-bonds }
+## Manage Session Keys {: #manage-session-keys }
 
-There is a bond that is sent when mapping your session keys with your account. This bond is per session keys registered. The bond set is as follows:
+Once you've created or rotated your session keys, you'll be able to manage your session keys using the extrinsics in the Author Mapping Pallet. You can map your session keys, verify the on-chain mappings, and remove session keys.
+
+### Author Mapping Pallet Interface {: #author-mapping-interface }
+
+The `authorMapping` module has the following extrinsics:
+
+ - **setKeys**(keys) — accepts the result of calling `author_rotateKeys`, which is the concatenated public keys of your Nimbus and VRF keys, and sets the session keys at once. Useful after a key rotation or migration. Calling `setKeys` requires a [bond](#mapping-bonds). Replaces the deprecated `addAssociation` and `updateAssociation` extrinsics
+- **removeKeys**() - removes the session keys. Replaces the deprecated `clearAssociation` extrinsic
+
+The module also adds the following RPC calls (chain state):
+
+- **mappingWithDeposit**(NimbusPrimitivesNimbusCryptoPublic | string | Uint8Array) — displays all mappings stored on-chain, or only that related to the Nimbus ID if provided
+- **nimbusLookup**(AccountId20) - displays a reverse mapping of account IDs to Nimbus IDs for all collators or for a given collator address
+
+### Map Session Keys {: #mapping-extrinsic }
+
+With your newly generated session keys in hand, the next step is to map your session keys to your H160 account (an Ethereum-style address). Make sure you hold the private keys to this account, as this is where the block rewards are paid out to.
+
+To map your session keys to your account, you need to be inside the [candidate pool](/node-operators/networks/collators/activities/#become-a-candidate){target=_blank}. Once you are a candidate, you need to send a mapping extrinsic, which requires a mapping bond.
+
+#### Mapping Bonds {: #mapping-bonds }
+
+The mapping bond is per session keys registered. The bond for mapping your session keys to your account is as follows:
 
 === "Moonbeam"
     ```
@@ -38,31 +70,9 @@ There is a bond that is sent when mapping your session keys with your account. T
     {{ networks.moonbase.staking.collator_map_bond }} DEV
     ```
 
-## Author Mapping Pallet Interface {: #author-mapping-interface }
+#### Use Polkadot.js Apps to Map Session Keys {: #use-polkadotjs-apps }
 
-The `authorMapping` module has the following extrinsics programmed:
-
- - **setKeys**(keys) — accepts the result of calling `author_rotateKeys`, which is the concatenated public keys of your Nimbus and VRF keys, and sets the session keys at once. Useful after a key rotation or migration. Calling `setKeys` requires a [bond](#mapping-bonds). Replaces the deprecated `addAssociation` and `updateAssociation` extrinsics
-- **removeKeys**() - removes the session keys. Replaces the deprecated `clearAssociation` extrinsic
-
-The following methods are **deprecated**, but will still exist for backwards compatibility:
-
- - **addAssociation**(nimbusId) — maps your Nimbus ID to the H160 account from which the transaction is being sent, ensuring it is the true owner of its private keys. It requires a [bond](#mapping-bonds). This method maintains backwards compatibility by setting the `keys` to the Nimbus ID by default
- - **updateAssociation**(oldNimbusId, newNimbusId) —  updates the mapping from an old Nimbus ID to a new one. Useful after a key rotation or migration. It executes both the `add` and `clear` association extrinsics automically, enabling key rotation without needing a second bond. This method maintains backwards compatibility by setting the `newKeys` to the Nimbus ID by default
- - **clearAssociation**(nimbusId) — clears the association of a Nimbus ID to the H160 account from which the transaction is being sent, which needs to be the owner of that Nimbus ID. Also refunds the bond
-
-The module also adds the following RPC calls (chain state):
-
-- **mappingWithDeposit**(NimbusPrimitivesNimbusCryptoPublic | string | Uint8Array) — displays all mappings stored on-chain, or only that related to the Nimbus ID if provided
-- **nimbusLookup**(AccountId20) - displays a reverse mapping of account IDs to Nimbus IDs for all collators or for a given collator address
-
-## Map Session Keys {: #mapping-extrinsic } 
-
-Once you've generated your session keys, the next step is to map your session keys to your H160 account (an Ethereum-style address). Make sure you hold the private keys to this account, as this is where the block rewards are paid out to.
-
-To map your session keys to your account, you need to be inside the [candidate pool](/node-operators/networks/collators/activities/#become-a-candidate){target=_blank}. Once you are a candidate, you need to send a mapping extrinsic. Note that this will bond tokens per author ID registered.
-
-In this guide, you'll learn how to map session keys from Polkadot.js Apps. To learn how to create the mapping through the author mapping precompiled contract, you can refer to the page on [Interacting with the Author Mapping Precompile](/builders/pallets-precompiles/precompiles/author-mapping){target=_blank}.
+In this section, you'll learn how to map session keys from Polkadot.js Apps. To learn how to create the mapping through the author mapping precompiled contract, you can refer to the page on [Interacting with the Author Mapping Precompile](/builders/pallets-precompiles/precompiles/author-mapping){target=_blank}.
 
 To create the mapping from [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase.moonbeam.network#/assets){target=_blank} (make sure you're connected to the correct network), click on **Developer** at the top of the page, choose the **Extrinsics** option from the dropdown, and take the following steps:
 
@@ -74,17 +84,18 @@ To create the mapping from [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=
 
 ![Author ID Mapping to Account Extrinsic](/images/node-operators/networks/collators/account-management/account-3.png)
 
+!!! note
+    If you receive the following error, you may need to try rotating and mapping your keys again: `VRF PreDigest was not included in the digests (check rand key is in keystore)`.
+
 If the transaction is successful, you will see a confirmation notification on your screen. If not, make sure you've [joined the candidate pool](/node-operators/networks/collators/activities/#become-a-candidate){target=_blank}.
 
-If you receive the following error, you may need to try rotating and mapping your keys again: `VRF PreDigest was not included in the digests (check rand key is in keystore)`
-
-## Check Mappings {: #checking-the-mappings } 
+### Check Mappings {: #checking-the-mappings }
 
 You can check the current on-chain mappings by verifying the chain state. You can do this one of two ways: via the `mappingWithDeposit` method or the `nimbusLookup` method. Both methods can be used to query the on-chain data for all of the collators or for a specific collator.
 
-You can check the current on-chain mappings for a specific collator or you can also check all of the mappings stored on-chain. 
+You can check the current on-chain mappings for a specific collator or you can also check all of the mappings stored on-chain.
 
-### Using the Mapping with Deposit Method {: #using-mapping-with-deposit }
+#### Using the Mapping with Deposit Method {: #using-mapping-with-deposit }
 
 To use the `mappingWithDeposit` method to check the mapping for a specific collator, you'll need to get the Nimbus ID. To do so, you can take the first 64 hexadecimal characters of the concatenated public keys to get the Nimbus ID. To verify that the Nimbus ID is correct, you can run the following command with the first 64 characters passed into the `params` array:
 
@@ -112,7 +123,7 @@ From [Polkadot.js Apps](https://polkadot.js.org/apps/?rpc=wss://wss.api.moonbase
 
 You should be able to see the H160 account associated with the Nimbus ID provided and the deposit paid. If no Nimbus ID was included, this would return all the mappings stored on-chain.
 
-### Using the Nimbus Lookup Method {: #using-nimbus-lookup }
+#### Using the Nimbus Lookup Method {: #using-nimbus-lookup }
 
 To use the `nimbusLookup` method to check the mapping for a specific collator, you'll need the collator's address. If you do not pass an argument to the method, you can retrieve all of the on-chain mappings.
 
@@ -129,12 +140,12 @@ You should be able to see the nimbus ID associated with the H160 account provide
 
 ## Setting an Identity {: #setting-an-identity }
 
-Setting an on-chain identity enables your collator node to be easily identifiable. As opposed to showing your account address, your chosen display name will be displayed instead. 
+Setting an on-chain identity enables your collator node to be easily identifiable. As opposed to showing your account address, your chosen display name will be displayed instead.
 
 There are a couple of ways you can set your identity, to learn how to set an identity for your collator node please check out the [Managing your Account Identity](/tokens/manage/identity/){target=_blank} page of our documentation.
 
 ## Proxy Accounts {: #proxy-accounts }
 
-Proxy accounts are accounts that can be enabled to perform a limited number of actions on your behalf. Proxies allow users to keep a primary account securely in cold storage while using the proxy to actively participate in the network on behalf of the primary account. You can remove authorization of the proxy account at any time. As an additional layer of security, you can setup your proxy with a delay period. This delay period would provide you time to review the transaction, and cancel if needed, before it automatically gets executed. 
+Proxy accounts are accounts that can be enabled to perform a limited number of actions on your behalf. Proxies allow users to keep a primary account securely in cold storage while using the proxy to actively participate in the network on behalf of the primary account. You can remove authorization of the proxy account at any time. As an additional layer of security, you can setup your proxy with a delay period. This delay period would provide you time to review the transaction, and cancel if needed, before it automatically gets executed.
 
 To learn how to setup a proxy account, please refer to the [Setting up a Proxy Account](/tokens/manage/proxy-accounts/){target=_blank} page of our documentation.

--- a/node-operators/networks/collators/account-management.md
+++ b/node-operators/networks/collators/account-management.md
@@ -38,7 +38,7 @@ Once you've created or rotated your session keys, you'll be able to manage your 
 The `authorMapping` module has the following extrinsics:
 
  - **setKeys**(keys) — accepts the result of calling `author_rotateKeys`, which is the concatenated public keys of your Nimbus and VRF keys, and sets the session keys at once. Useful after a key rotation or migration. Calling `setKeys` requires a [bond](#mapping-bonds). Replaces the deprecated `addAssociation` and `updateAssociation` extrinsics
-- **removeKeys**() - removes the session keys. Replaces the deprecated `clearAssociation` extrinsic
+- **removeKeys**() - removes the session keys. This is only required if you intend to stop collating and leave the candidate pool. Replaces the deprecated `clearAssociation` extrinsic
 
 The module also adds the following RPC calls (chain state):
 


### PR DESCRIPTION
### Description

This PR addresses the following items:
- Adds new section that outlines the steps that a user has to take to create or rotate their session keys
- Removes deprecated extrinsics
- Reorganizes content

### Checklist

- [x] If this requires translations for the `moonbeam-docs-cn` repo, I have created a ticket for the translations in Jira

### After Translation Requirements

- [x] No additional PRs are required after the translations are done
